### PR TITLE
Feature/116 server polling

### DIFF
--- a/ui/projects/spline-shared/dynamic-table/main/assets/i18n/shared-dynamic-table/en.json
+++ b/ui/projects/spline-shared/dynamic-table/main/assets/i18n/shared-dynamic-table/en.json
@@ -2,7 +2,9 @@
     "SHARED": {
         "DYNAMIC_TABLE": {
             "DS_WRITE_MODE__APPEND": "Append",
-            "DS_WRITE_MODE__OVERRIDE": "Override"
+            "DS_WRITE_MODE__OVERRIDE": "Override",
+            "BUTTON__REFRESH": "Refresh",
+            "TOOLTIP__UPDATE_AVAILABLE": "New data is available on the server"
         }
     }
 }

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.html
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.html
@@ -35,6 +35,20 @@
                 </spline-search-box>
             </div>
             <!-- ./SEARCH -->
+
+            <!-- UPDATE NOTIFICATION -->
+            <div class="flex-grow-1">
+                <button mat-raised-button color="accent"
+                        *ngIf="isDataUpdateAvailable$ | async"
+                        [matTooltip]="'SHARED.DYNAMIC_TABLE.TOOLTIP__UPDATE_AVAILABLE' | translate"
+                        (click)="onRefreshDataClick()"
+                        >
+                    <mat-icon>refresh</mat-icon>
+                    {{ 'SHARED.DYNAMIC_TABLE.BUTTON__REFRESH' | translate }}
+                </button>
+            </div>
+            <!-- ./UPDATE NOTIFICATION -->
+
             <div>
                 <!-- FILTERS -->
                 <ng-content></ng-content>

--- a/ui/projects/spline-shared/dynamic-table/main/src/spline-dynamic-table-shared.module.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/spline-dynamic-table-shared.module.ts
@@ -17,7 +17,9 @@
 
 import { CommonModule } from '@angular/common'
 import { NgModule } from '@angular/core'
+import { MatButtonModule } from '@angular/material/button'
 import { MatPaginatorModule } from '@angular/material/paginator'
+import { MatTooltipModule } from '@angular/material/tooltip'
 import { SplineCommonModule } from 'spline-common'
 import { DynamicTableModule } from 'spline-common/dynamic-table'
 import { SplineTranslateModule } from 'spline-utils/translate'
@@ -28,6 +30,8 @@ import { splineDtSharedComponents } from './components'
 @NgModule({
     imports: [
         CommonModule,
+        MatButtonModule,
+        MatTooltipModule,
         MatPaginatorModule,
         DynamicTableModule,
         SplineCommonModule,

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -16,8 +16,8 @@
 
 import { CollectionViewer, DataSource } from '@angular/cdk/collections'
 import { isEqual } from 'lodash-es'
-import { BehaviorSubject, Observable, of, Subject } from 'rxjs'
-import { catchError, filter, map, switchMap, take, takeUntil, tap } from 'rxjs/operators'
+import { BehaviorSubject, interval, Observable, of, Subject } from 'rxjs'
+import { catchError, filter, map, multicast, refCount, switchMap, take, takeUntil, tap } from 'rxjs/operators'
 
 import { ProcessingStore } from '../../../store'
 import { SplineRecord, StringHelpers } from '../heplers'
@@ -27,6 +27,7 @@ import { SearchQuery } from './search-query.models'
 import DataState = SearchQuery.DataState
 import DEFAULT_RENDER_DATA = SearchQuery.DEFAULT_RENDER_DATA
 import DEFAULT_SEARCH_PARAMS = SearchQuery.DEFAULT_SEARCH_PARAMS
+import DEFAULT_SERVER_POLLING_INTERVAL = SearchQuery.DEFAULT_SERVER_POLL_INTERVAL
 import SearchParams = SearchQuery.SearchParams
 
 
@@ -39,6 +40,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
     readonly searchParams$: Observable<SearchParams<TFilter, TSortableFields>>
     readonly loadingProcessing$: Observable<ProcessingStore.EventProcessingState>
     readonly loadingProcessingEvents: ProcessingStore.ProcessingEvents<DataState<TData>>
+    readonly serverDataUpdates$: Observable<TData>
 
     readonly onFilterChanged$ = new Subject<{ filter: TFilter; apply: boolean; force: boolean }>()
     readonly onSearch$ = new Subject<{ searchTerm: string; apply: boolean; force: boolean }>()
@@ -58,6 +60,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
     protected _defaultSearchParams: SearchParams<TFilter, TSortableFields> = DEFAULT_SEARCH_PARAMS
     protected readonly _disconnected$ = new Subject<void>()
 
+    protected _serverDataUpdates$ = new Subject<TData>()
 
     protected constructor() {
 
@@ -69,6 +72,8 @@ export abstract class SearchDataSource<TDataRecord = unknown,
         this.loadingProcessingEvents = ProcessingStore.createProcessingEvents(
             this.dataState$, (state) => state.loadingProcessing,
         )
+
+        this.serverDataUpdates$ = this.createServerDataUpdatePoller()
 
         this.init()
     }
@@ -209,6 +214,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
         this.entitiesList$.complete()
         this._dataState$.complete()
         this._searchParams$.complete()
+        this._serverDataUpdates$.complete()
 
         this._disconnected$.next()
         this._disconnected$.complete()
@@ -289,6 +295,37 @@ export abstract class SearchDataSource<TDataRecord = unknown,
             )
             .subscribe(
                 (payload) => this.processOnFilterChangedEvent(payload.filter, payload.apply, payload.force),
+            )
+    }
+
+    protected createServerDataUpdatePoller(): Observable<TData> {
+        // Poll the server using the same search query as the main one, but with `asAtTime = now()`.
+        // If the returned data differs from what the data source currently holds then an update notification
+        // is sent to the observers.
+
+        // The observable is multicast with active subscription counting.
+        // The polling stops when `count == 0` and it resumes when `count > 0`
+
+        return interval(DEFAULT_SERVER_POLLING_INTERVAL)
+            .pipe(
+                switchMap(() => {
+                    const lastSearchParams = this._searchParams$.getValue()
+                    const freshSearchParams = {
+                        ...lastSearchParams,
+                        filter: {
+                            ...lastSearchParams.filter,
+                            asAtTime: undefined
+                        }
+                    }
+                    return this.getDataObserver(freshSearchParams, undefined)
+                        .pipe(
+                            take(1),
+                            catchError(() => this._dataState$.pipe(map(state => state.data)))
+                        )
+                }),
+                multicast(this._serverDataUpdates$),
+                refCount(),
+                filter(serverData => !isEqual(serverData.items, this._dataState$.getValue().data.items))
             )
     }
 

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -20,6 +20,7 @@ import { BehaviorSubject, interval, Observable, of, Subject } from 'rxjs'
 import { catchError, filter, map, multicast, refCount, switchMap, take, takeUntil, tap } from 'rxjs/operators'
 
 import { ProcessingStore } from '../../../store'
+import { whenPageVisible } from '../../rxjs-operators'
 import { SplineRecord, StringHelpers } from '../heplers'
 import { PageResponse, QuerySorter } from '../query'
 
@@ -308,6 +309,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
 
         return interval(DEFAULT_SERVER_POLLING_INTERVAL)
             .pipe(
+                whenPageVisible(),
                 switchMap(() => {
                     const lastSearchParams = this._searchParams$.getValue()
                     const freshSearchParams = {

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-query.models.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-query.models.ts
@@ -54,6 +54,8 @@ export namespace SearchQuery {
         loadingProcessing: ProcessingStore.getDefaultProcessingState(),
     }
 
+    export const DEFAULT_SERVER_POLL_INTERVAL = 5000 // msec
+
     export function toMatSortable(fieldSorter: QuerySorter.FieldSorter, disableClear = true): MatSortable {
         return {
             id: fieldSorter.field,

--- a/ui/projects/spline-utils/main/src/common/rxjs-operators/index.ts
+++ b/ui/projects/spline-utils/main/src/common/rxjs-operators/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './public-api'

--- a/ui/projects/spline-utils/main/src/common/rxjs-operators/public-api.ts
+++ b/ui/projects/spline-utils/main/src/common/rxjs-operators/public-api.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './when-page-visible.operator'

--- a/ui/projects/spline-utils/main/src/common/rxjs-operators/when-page-visible.operator.ts
+++ b/ui/projects/spline-utils/main/src/common/rxjs-operators/when-page-visible.operator.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fromEvent, Observable } from 'rxjs'
+import { filter, repeatWhen, shareReplay, takeUntil } from 'rxjs/operators'
+
+
+export function whenPageVisible() {
+    const visibilitychange$ = fromEvent(document, 'visibilitychange').pipe(
+        shareReplay({ refCount: true, bufferSize: 1 })
+    )
+
+    const pageVisible$ = visibilitychange$.pipe(
+        filter(() => document.visibilityState === 'visible')
+    )
+
+    const pageHidden$ = visibilitychange$.pipe(
+        filter(() => document.visibilityState === 'hidden')
+    )
+
+    return function <T>(source: Observable<T>) {
+        return source.pipe(
+            takeUntil(pageHidden$),
+            repeatWhen(() => pageVisible$)
+        )
+    }
+}


### PR DESCRIPTION
Add a server polling feature to the _Dynamic Table_ component to notify users when the view they are currently looking at has changed on the server. The updates are not obtrusive - it only shows a notification with the _Refresh_ button but the view isn't updated automatically allowing users to continue working with the fixed time snapshot if they want to (e.g. maintaining consistent pagination, sorting etc)

The polling interval is set to __5 seconds__.
For saving on the client and the server CPU time and unnecessary network traffic, polling stops when the _Refresh_ button is displayed, or the page goes invisible (the browser window is minimized or the tab switched). Polling resumes when the view is refreshed, or the page goes visible again respectively to the reason is was paused.

![image](https://user-images.githubusercontent.com/795479/132850552-e796ada0-8101-452c-83e4-c97711b8306c.png)
