### PR TITLE
Bugfix/spline UI 138 refresh view on main menu click

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -151,7 +151,7 @@ module.exports = {
                         'accessibility': 'no-public'
                     }
                 ],
-                '@typescript-eslint/member-ordering': 'error',
+                '@typescript-eslint/member-ordering': 'warn',
                 'no-multiple-empty-lines': 'off',
                 'no-empty': 'off',
                 '@typescript-eslint/no-inferrable-types': [

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,7 +12,7 @@
     "build::CDN": "ng build --prod",
     "postbuild": "shx mkdir dist/app/ && shx mv dist/index.html dist/app/ && shx mv dist/assets dist/app/",
     "test": "jest --passWithNoTests --coverage",
-    "test:no-covarege": "jest --passWithNoTests",
+    "test:no-coverage": "jest --passWithNoTests",
     "lint": "npm run lint:ts && npm run lint:styles",
     "lint:ts": "eslint src/**/*.ts projects/**/*.ts --quiet",
     "lint:ts:fix": "eslint src/**/*.ts projects/**/*.ts --fix",
@@ -21,7 +21,7 @@
     "e2e": "ng e2e",
     "ngcc": "ngcc --properties es2015 browser module main --async false",
     "license-check": "cd ../ && mvn validate -Plicense-check",
-    "pre-pull-request": "npm run lint && npm run test:no-covarege && npm run license-check"
+    "pre-pull-request": "npm run lint && npm run test:no-coverage && npm run license-check"
   },
   "private": false,
   "dependencies": {

--- a/ui/projects/spline-api/src/lib/execution-event/models/entities/execution-event/execution-events-query.models.ts
+++ b/ui/projects/spline-api/src/lib/execution-event/models/entities/execution-event/execution-events-query.models.ts
@@ -15,7 +15,7 @@
  */
 
 import { HttpParams } from '@angular/common/http'
-import { DEFAULT_PAGE_LIMIT, PageQueryParams, QueryPager, QuerySorter } from 'spline-utils'
+import { DEFAULT_PAGE_LIMIT, PageQueryParams, QueryPager, QuerySorter, SearchQuery } from 'spline-utils'
 
 import { DataSourceWriteMode } from '../data-source'
 
@@ -72,6 +72,22 @@ export namespace ExecutionEventsQuery {
         const queryParamsDto = toQueryParamsDto(queryParams)
         return queryParamsDtoToHttpParams(queryParamsDto)
     }
+
+    export function toQueryParams(
+        searchParams: SearchQuery.SearchParams<QueryFilter, ExecutionEventField>,
+    ): QueryParams {
+        const queryFilter = {
+            ...searchParams.filter,
+            ...searchParams.alwaysOnFilter,
+            searchTerm: searchParams.searchTerm,
+        }
+        return {
+            filter: queryFilter,
+            pager: searchParams.pager,
+            sortBy: searchParams.sortBy,
+        }
+    }
+
 
     function toQueryFilterDto(queryFilter: QueryFilter): Partial<QueryParamsDto> {
         return {

--- a/ui/projects/spline-common/dynamic-table/src/core/components/table/dynamic-table.component.html
+++ b/ui/projects/spline-common/dynamic-table/src/core/components/table/dynamic-table.component.html
@@ -23,8 +23,8 @@
                    matSort
                    (matSortChange)="onSortChanged($event)"
                    [matSortDisableClear]="true"
-                   [matSortActive]="initSorting?.field"
-                   [matSortDirection]="initSorting?.dir?.toLowerCase()">
+                   [matSortActive]="sorting?.field"
+                   [matSortDirection]="sorting?.dir?.toLowerCase()">
 
             <!-- DATA COLUMNS -->
             <ng-container [matColumnDef]="columnSchema.id" *ngFor="let columnSchema of dataMap">

--- a/ui/projects/spline-common/dynamic-table/src/core/components/table/dynamic-table.component.ts
+++ b/ui/projects/spline-common/dynamic-table/src/core/components/table/dynamic-table.component.ts
@@ -45,7 +45,7 @@ export class DynamicTableComponent<TRowData> extends BaseLocalStateComponent<Dyn
     @Input() dataMap: DynamicTableDataMap
 
     @Input() options: Readonly<DynamicTableOptions> = getDefaultDtOptions()
-    @Input() initSorting: Readonly<QuerySorter.FieldSorter>
+    @Input() sorting: Readonly<QuerySorter.FieldSorter>
 
     // events
     @Output() sortingChanged$ = new EventEmitter<QuerySorter.FieldSorter>()

--- a/ui/projects/spline-shared/attributes/src/data-sources/attribute-search.data-source.ts
+++ b/ui/projects/spline-shared/attributes/src/data-sources/attribute-search.data-source.ts
@@ -30,11 +30,7 @@ export class AttributeSearchDataSource extends SimpleDataSource<SplineAttributeS
         super()
     }
 
-    protected getDataObserver(
-        filterValue: AttributeSearchDataSourceFilter,
-        force: boolean,
-    ): Observable<SplineAttributeSearch.Data> {
-
+    protected getDataObserver(filterValue: AttributeSearchDataSourceFilter): Observable<SplineAttributeSearch.Data> {
         return filterValue?.search?.length
             ? this.attributeFacade.search(filterValue.search)
             : of([])

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
@@ -117,7 +117,7 @@ describe('SplineSearchDynamicTableComponent', () => {
             componentInstance.dataSource = fakeDataSource
             componentInstance.dataMap = dataMap
 
-            fakeDataSource.updateAndApplyDefaultSearchParams({
+            fakeDataSource.updateDefaultSearchParams({
                 sortBy: [{ ...defaultSortBy }]
             })
         })
@@ -156,7 +156,6 @@ describe('SplineSearchDynamicTableComponent', () => {
             const queryParams = SplineSearchDynamicTable.applySearchParams(
                 {},
                 componentInstance.defaultUrlStateQueryParamAlias,
-                fakeDataSource,
                 urlSearchParams
             )
 

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
@@ -29,10 +29,10 @@ import { filter, take } from 'rxjs/operators'
 import { SplineSearchBoxModule, SplineSortHeaderModule } from 'spline-common'
 import { DynamicTableDataMap, DynamicTableModule } from 'spline-common/dynamic-table'
 import { SplineDynamicTableSharedModule, SplineSearchDynamicTable, SplineSearchDynamicTableComponent } from 'spline-shared/dynamic-table'
-import { PageResponse, QuerySorter, SearchDataSource, SearchDataSourceConfig, SearchQuery } from 'spline-utils'
+import { PageResponse, QuerySorter, SearchDataSource, SearchDataSourceConfigInput, SearchQuery } from 'spline-utils'
 import { SplineTranslateTestingModule } from 'spline-utils/translate'
-import SortDir = QuerySorter.SortDir
-import SearchParams = SearchQuery.SearchParams
+import SortDir = QuerySorter.SortDir;
+import SearchParams = SearchQuery.SearchParams;
 
 
 describe('SplineSearchDynamicTableComponent', () => {
@@ -92,7 +92,7 @@ describe('SplineSearchDynamicTableComponent', () => {
 
         class FakeDataSource extends SearchDataSource<FakeItem> {
 
-            constructor(config: Partial<SearchDataSourceConfig>) {
+            constructor(config: SearchDataSourceConfigInput<any, any>) {
                 super(config)
             }
 
@@ -167,7 +167,7 @@ describe('SplineSearchDynamicTableComponent', () => {
                     filter(event => event instanceof NavigationEnd),
                     take(1)
                 )
-                .subscribe((event: NavigationEnd) => {
+                .subscribe(() => {
                     // init component after router state is init
                     componentFixture.detectChanges()
 

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
@@ -29,7 +29,7 @@ import { filter, take } from 'rxjs/operators'
 import { SplineSearchBoxModule, SplineSortHeaderModule } from 'spline-common'
 import { DynamicTableDataMap, DynamicTableModule } from 'spline-common/dynamic-table'
 import { SplineDynamicTableSharedModule, SplineSearchDynamicTable, SplineSearchDynamicTableComponent } from 'spline-shared/dynamic-table'
-import { PageResponse, QuerySorter, SearchDataSource, SearchQuery } from 'spline-utils'
+import { PageResponse, QuerySorter, SearchDataSource, SearchDataSourceConfig, SearchQuery } from 'spline-utils'
 import { SplineTranslateTestingModule } from 'spline-utils/translate'
 import SortDir = QuerySorter.SortDir
 import SearchParams = SearchQuery.SearchParams
@@ -92,8 +92,8 @@ describe('SplineSearchDynamicTableComponent', () => {
 
         class FakeDataSource extends SearchDataSource<FakeItem> {
 
-            constructor() {
-                super()
+            constructor(config: Partial<SearchDataSourceConfig>) {
+                super(config)
             }
 
 
@@ -113,13 +113,13 @@ describe('SplineSearchDynamicTableComponent', () => {
         }
 
         beforeEach(() => {
-            fakeDataSource = new FakeDataSource()
+            fakeDataSource = new FakeDataSource({
+                defaultSearchParams: {
+                    sortBy: [{ ...defaultSortBy }]
+                }
+            })
             componentInstance.dataSource = fakeDataSource
             componentInstance.dataMap = dataMap
-
-            fakeDataSource.updateDefaultSearchParams({
-                sortBy: [{ ...defaultSortBy }]
-            })
         })
 
 

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
@@ -128,10 +128,6 @@ describe('SplineSearchDynamicTableComponent', () => {
             componentFixture.detectChanges()
 
             componentInstance.state$
-                .pipe(
-                    filter(state => state.isInitialized),
-                    take(1),
-                )
                 .subscribe((state) => {
                     expect(state.sorting).toEqual(defaultSortBy)
                     done()
@@ -176,10 +172,6 @@ describe('SplineSearchDynamicTableComponent', () => {
                     componentFixture.detectChanges()
 
                     componentInstance.state$
-                        .pipe(
-                            filter(state => state.isInitialized),
-                            take(1),
-                        )
                         .subscribe((state) => {
                             // expect comp state was initialized from router
                             expect(state.sorting).toEqual(urlSorting)

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
@@ -33,6 +33,7 @@ import { PageResponse, QuerySorter, SearchDataSource, SearchDataSourceConfigInpu
 import { SplineTranslateTestingModule } from 'spline-utils/translate'
 import SortDir = QuerySorter.SortDir;
 import SearchParams = SearchQuery.SearchParams;
+import DEFAULT_SEARCH_PARAMS = SearchQuery.DEFAULT_SEARCH_PARAMS;
 
 
 describe('SplineSearchDynamicTableComponent', () => {
@@ -143,7 +144,7 @@ describe('SplineSearchDynamicTableComponent', () => {
             }
 
             const urlSearchParams: SearchParams = {
-                ...fakeDataSource.searchParams,
+                ...DEFAULT_SEARCH_PARAMS,
                 sortBy: [
                     urlSorting
                 ]
@@ -177,7 +178,7 @@ describe('SplineSearchDynamicTableComponent', () => {
                             expect(state.sorting).toEqual(urlSorting)
 
                             // expect DataSource search Params were sync with a Router state
-                            expect(fakeDataSource.searchParams).toEqual(urlSearchParams)
+                            expect(urlSearchParams.sortBy).toEqual([urlSorting])
                             done()
                         })
                 })

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
@@ -133,7 +133,7 @@ describe('SplineSearchDynamicTableComponent', () => {
                     take(1),
                 )
                 .subscribe((state) => {
-                    expect(state.initSorting).toEqual(defaultSortBy)
+                    expect(state.sorting).toEqual(defaultSortBy)
                     done()
                 })
 
@@ -182,7 +182,7 @@ describe('SplineSearchDynamicTableComponent', () => {
                         )
                         .subscribe((state) => {
                             // expect comp state was initialized from router
-                            expect(state.initSorting).toEqual(urlSorting)
+                            expect(state.sorting).toEqual(urlSorting)
 
                             // expect DataSource search Params were sync with a Router state
                             expect(fakeDataSource.searchParams).toEqual(urlSearchParams)

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/__tests__/spline-search-dynamic-table.component.spec.ts
@@ -97,7 +97,7 @@ describe('SplineSearchDynamicTableComponent', () => {
             }
 
 
-            protected getDataObserver(searchParams: SearchQuery.SearchParams, force: boolean): Observable<PageResponse<FakeItem>> {
+            protected getDataObserver(searchParams: SearchQuery.SearchParams): Observable<PageResponse<FakeItem>> {
                 return of({
                     totalCount: fakeData.length,
                     items: [...fakeData]

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.html
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.html
@@ -63,7 +63,7 @@
 
         <!--  TABLE  -->
         <dynamic-table [dataSource]="dataSource"
-                       [initSorting]="state.initSorting"
+                       [sorting]="state.sorting"
                        [dataMap]="dataMap"
                        [options]="options"
                        (sortingChanged$)="onSortingChanged($event)"

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
@@ -88,7 +88,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
                         asAtTime: new Date().getTime()
                     }
                 }
-                this.dataSource.updateSearchParams(freshDefaultParams)
+                this.dataSource.updateSearchParams(freshDefaultParams, true, false)
                 this._resumeListeningOnServerUpdates$.next()
             }
         })
@@ -140,7 +140,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
     }
 
     onRefreshDataClick(): void {
-        this.dataSource.updateSearchParams({ filter: { asAtTime: Date.now() } })
+        this.dataSource.updateSearchParams({ filter: { asAtTime: Date.now() } }, true, false)
         this._resumeListeningOnServerUpdates$.next()
     }
 
@@ -158,7 +158,6 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
             ? SplineSearchDynamicTable.extractSearchParamsFromUrl(
                 this.currentQueryParams,
                 this.urlStateQueryParamAlias,
-                this.dataSource
             )
             : null
     }
@@ -168,7 +167,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
         currentSearchParams?: SearchParams): void {
 
         if (currentSearchParams) {
-            dataSource.updateSearchParams({ ...currentSearchParams }, false)
+            dataSource.updateSearchParams({ ...currentSearchParams }, false, false)
         }
 
         const initSorting = dataSource.searchParams.sortBy.length > 0
@@ -258,7 +257,6 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
                 const queryParams = SplineSearchDynamicTable.applySearchParams(
                     this.currentQueryParams,
                     queryParamAlias,
-                    dataSource,
                     searchParams
                 )
                 this.updateRouterState(queryParams)

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
@@ -87,7 +87,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
         }
 
         // load data
-        this.dataSource.update(this.searchParamsFromUrl() || {})
+        this.dataSource.update(this.searchParamsFromUrl() ?? {})
     }
 
     ngOnChanges(changes: SimpleChanges): void {
@@ -225,11 +225,11 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
                 distinctUntilChanged((a, b) => isEqual(a, b)),
                 skip(1),
             )
-            .subscribe(() => {
+            .subscribe((searchParams) => {
                 const queryParams = SplineSearchDynamicTable.applySearchParams(
                     this.currentQueryParams,
                     queryParamAlias,
-                    dataSource.searchParams
+                    searchParams
                 )
                 this.updateRouterState(queryParams)
             })

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
@@ -28,10 +28,9 @@ import {
     DynamicTableOptions,
     getDefaultDtOptions
 } from 'spline-common/dynamic-table'
-import { BaseLocalStateComponent, QuerySorter, RouterNavigation, SearchDataSource, SearchQuery, SplineRecord } from 'spline-utils'
+import { BaseLocalStateComponent, QuerySorter, RouterNavigation, SearchDataSource, SplineRecord } from 'spline-utils'
 
 import { SplineSearchDynamicTable } from './spline-search-dynamic-table.models'
-import SearchParams = SearchQuery.SearchParams
 
 
 @Component({
@@ -81,6 +80,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
             takeUntil(this.destroyed$),
             filter((event: RouterEvent) => event instanceof NavigationEnd)
         ).subscribe(() => {
+            // console.log("ROUTE END: URL search params", this.searchParamsFromUrl())
             if (this.searchParamsFromUrl() === null) {
                 const freshDefaultParams = {
                     ...this.dataSource.defaultSearchParams,
@@ -105,6 +105,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
         }
 
         // load data
+        // console.log("NgInit: URL search params", this.searchParamsFromUrl())
         this.dataSource.updateSearchParams(this.searchParamsFromUrl() || {})
     }
 

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
@@ -80,9 +80,8 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
         this.router.events.pipe(
             takeUntil(this.destroyed$),
             filter((event: RouterEvent) => event instanceof NavigationEnd)
-        ).subscribe((v) => {
+        ).subscribe(() => {
             if (this.searchParamsFromUrl() === null) {
-                console.log('RESET')
                 const freshDefaultParams = {
                     ...this.dataSource.defaultSearchParams,
                     filter: {

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
@@ -88,12 +88,12 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
                         asAtTime: new Date().getTime()
                     }
                 }
-                this.dataSource.updateSearchParams(freshDefaultParams, true, false)
+                this.dataSource.updateSearchParams(freshDefaultParams)
                 this._resumeListeningOnServerUpdates$.next()
             }
         })
 
-        this.initDefaultState(this.dataSource, this.searchParamsFromUrl())
+        this.initDefaultState(this.dataSource)
         this.initDataSourceEvents(this.dataSource)
 
         // start listening on the server data updates
@@ -105,7 +105,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
         }
 
         // load data
-        this.dataSource.updateSearchParams({}, true, true)
+        this.dataSource.updateSearchParams(this.searchParamsFromUrl() || {})
     }
 
     ngOnChanges(changes: SimpleChanges): void {
@@ -140,7 +140,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
     }
 
     onRefreshDataClick(): void {
-        this.dataSource.updateSearchParams({ filter: { asAtTime: Date.now() } }, true, false)
+        this.dataSource.updateSearchParams({ filter: { asAtTime: Date.now() } })
         this._resumeListeningOnServerUpdates$.next()
     }
 
@@ -162,13 +162,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
             : null
     }
 
-    private initDefaultState(
-        dataSource: SearchDataSource<TRowData>,
-        currentSearchParams?: SearchParams): void {
-
-        if (currentSearchParams) {
-            dataSource.updateSearchParams({ ...currentSearchParams }, false, false)
-        }
+    private initDefaultState(dataSource: SearchDataSource<TRowData>): void {
 
         const initSorting = dataSource.searchParams.sortBy.length > 0
             ? dataSource.searchParams.sortBy[0]

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
@@ -105,7 +105,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
         }
 
         // load data
-        this.dataSource.load()
+        this.dataSource.updateSearchParams({}, true, true)
     }
 
     ngOnChanges(changes: SimpleChanges): void {

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
@@ -92,8 +92,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
             }
         })
 
-        this.initDefaultState(this.dataSource)
-        this.initDataSourceEvents(this.dataSource)
+        this.subscribeToDataSource(this.dataSource)
 
         // start listening on the server data updates
         this.initDataUpdateAvailableObservable(this.dataSource)
@@ -161,22 +160,7 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
             : null
     }
 
-    private initDefaultState(dataSource: SearchDataSource<TRowData>): void {
-
-        const initSorting = dataSource.searchParams.sortBy.length > 0
-            ? dataSource.searchParams.sortBy[0]
-            : null
-
-        this.updateState({
-            initSorting,
-            isInitialized: true,
-            totalCount: dataSource.dataState.data?.totalCount ?? 0,
-            loadingProcessing: { ...dataSource.dataState.loadingProcessing },
-            searchParams: { ...dataSource.searchParams }
-        })
-    }
-
-    private initDataSourceEvents(dataSource: SearchDataSource<TRowData>): void {
+    private subscribeToDataSource(dataSource: SearchDataSource<TRowData>): void {
         // totalCount
         dataSource.dataState$
             .pipe(
@@ -210,13 +194,16 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
                 skip(1),
                 distinctUntilChanged((left, right) => isEqual(left, right))
             )
-            .subscribe(
-                searchParams => this.updateState({
-                    searchParams
-                })
-            )
+            .subscribe(searchParams => {
+                const sorting = searchParams.sortBy.length > 0
+                    ? searchParams.sortBy[0]
+                    : null
 
-        // TODO :: SearchParams sort changed => update table sorting
+                this.updateState({
+                    sorting: sorting,
+                    searchParams: { ...searchParams }
+                })
+            })
     }
 
     private initDataUpdateAvailableObservable(dataSource: SearchDataSource<TRowData>): void {

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.component.ts
@@ -80,7 +80,6 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
             takeUntil(this.destroyed$),
             filter((event: RouterEvent) => event instanceof NavigationEnd)
         ).subscribe(() => {
-            // console.log("ROUTE END: URL search params", this.searchParamsFromUrl())
             if (this.searchParamsFromUrl() === null) {
                 const freshDefaultParams = {
                     ...this.dataSource.defaultSearchParams,
@@ -105,7 +104,6 @@ export class SplineSearchDynamicTableComponent<TRowData = undefined, TFilter ext
         }
 
         // load data
-        // console.log("NgInit: URL search params", this.searchParamsFromUrl())
         this.dataSource.updateSearchParams(this.searchParamsFromUrl() || {})
     }
 

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.models.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.models.ts
@@ -26,7 +26,7 @@ export namespace SplineSearchDynamicTable {
 
     export type State = {
         isInitialized: boolean
-        initSorting: QuerySorter.FieldSorter | null
+        sorting: QuerySorter.FieldSorter | null
         searchParams: SearchParams | null
         totalCount: number
         loadingProcessing: ProcessingStore.EventProcessingState
@@ -35,7 +35,7 @@ export namespace SplineSearchDynamicTable {
     export function getDefaultState(): State {
         return {
             isInitialized: false,
-            initSorting: null,
+            sorting: null,
             totalCount: 0,
             searchParams: null,
             loadingProcessing: ProcessingStore.getDefaultProcessingState(true)

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.models.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.models.ts
@@ -16,7 +16,7 @@
 
 
 import { Params } from '@angular/router'
-import { ProcessingStore, QuerySorter, RouterNavigation, SearchDataSource, SearchQuery, StringHelpers } from 'spline-utils'
+import { ProcessingStore, QuerySorter, RouterNavigation, SearchQuery, StringHelpers } from 'spline-utils'
 
 
 export namespace SplineSearchDynamicTable {

--- a/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.models.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/components/search-dynamic-table/spline-search-dynamic-table.models.ts
@@ -16,7 +16,7 @@
 
 
 import { Params } from '@angular/router'
-import { ProcessingStore, QuerySorter, RouterNavigation, SearchDataSource, SearchQuery } from 'spline-utils'
+import { ProcessingStore, QuerySorter, RouterNavigation, SearchDataSource, SearchQuery, StringHelpers } from 'spline-utils'
 
 
 export namespace SplineSearchDynamicTable {
@@ -44,24 +44,22 @@ export namespace SplineSearchDynamicTable {
 
     export function extractSearchParamsFromUrl(
         queryParams: Params,
-        queryParamAlias: string,
-        dataSource: SearchDataSource): SearchParams | null {
+        queryParamAlias: string): SearchParams | null {
 
         const urlString = queryParams[queryParamAlias]
         return urlString
-            ? dataSource.searchParamsFromUrlString(urlString)
+            ? searchParamsFromUrlString(urlString)
             : null
     }
 
     export function applySearchParams(
         queryParams: Params,
         queryParamAlias: string,
-        dataSource: SearchDataSource,
         searchParams: SearchParams | null): Params {
 
         // keep some data in query params if it differs from the DS State
         const searchParamsString = searchParams !== null
-            ? dataSource.searchParamsToUrlString(searchParams)
+            ? searchParamsToUrlString(searchParams)
             : null
 
         return RouterNavigation.setQueryParam(
@@ -69,5 +67,13 @@ export namespace SplineSearchDynamicTable {
             queryParamAlias,
             searchParamsString,
         )
+    }
+
+    function searchParamsToUrlString(searchParams: SearchParams): string {
+        return StringHelpers.encodeObjToUrlString(searchParams)
+    }
+
+    function searchParamsFromUrlString(searchParamsUrlString: string): SearchParams {
+        return StringHelpers.decodeObjFromUrlString(searchParamsUrlString)
     }
 }

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -35,7 +35,7 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
     constructor(protected readonly executionEventFacade: ExecutionEventFacade) {
         super()
 
-        this.updateAndApplyDefaultSearchParams({
+        this.updateDefaultSearchParams({
             filter: {
                 asAtTime: new Date().getTime()
             },

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -57,7 +57,7 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
             )
 
         if (!searchParams) {
-            return { ...this.defaultSearchParams}
+            return { ...this.defaultSearchParams }
         }
 
         return {

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -15,16 +15,10 @@
  */
 
 import { Observable } from 'rxjs'
-import {
-    ExecutionEvent,
-    ExecutionEventFacade,
-    ExecutionEventField,
-    ExecutionEventsPageResponse,
-    ExecutionEventsQuery,
-} from 'spline-api'
-import { QuerySorter, SearchDataSource, SearchQuery, StringHelpers } from 'spline-utils'
-import SortDir = QuerySorter.SortDir
-import SearchParams = SearchQuery.SearchParams
+import { ExecutionEvent, ExecutionEventFacade, ExecutionEventField, ExecutionEventsPageResponse, ExecutionEventsQuery } from 'spline-api'
+import { QuerySorter, SearchDataSource, SearchQuery } from 'spline-utils'
+import SortDir = QuerySorter.SortDir;
+import SearchParams = SearchQuery.SearchParams;
 
 
 export class EventsDataSource extends SearchDataSource<ExecutionEvent,
@@ -46,28 +40,8 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
                 }
             ]
         })
-    }
 
-    searchParamsFromUrlString(
-        searchParamsUrlString: string): SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField> {
-
-        const searchParams = StringHelpers
-            .decodeObjFromUrlString<SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>>(
-                searchParamsUrlString
-            )
-
-        if (!searchParams) {
-            return { ...this.defaultSearchParams }
-        }
-
-        return {
-            ...searchParams,
-            filter: {
-                ...searchParams.filter,
-                executedAtFrom: searchParams.filter.executedAtFrom ? new Date(searchParams.filter.executedAtFrom) : undefined,
-                executedAtTo: searchParams.filter.executedAtTo ? new Date(searchParams.filter.executedAtTo) : undefined,
-            }
-        }
+        this.updateSearchParams(this.defaultSearchParams)
     }
 
     protected getDataObserver(

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import { Observable, of } from 'rxjs'
-import { map } from 'rxjs/operators'
+import { Observable } from 'rxjs'
 import { ExecutionEvent, ExecutionEventFacade, ExecutionEventField, ExecutionEventsPageResponse, ExecutionEventsQuery } from 'spline-api'
-import { QuerySorter, SearchDataSource, SearchDataSourceConfig, SearchQuery } from 'spline-utils'
+import { QuerySorter, SearchDataSource, SearchQuery } from 'spline-utils'
 import SortDir = QuerySorter.SortDir;
 import SearchParams = SearchQuery.SearchParams;
 
@@ -28,27 +27,21 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
     ExecutionEventField> {
 
     constructor(
-        protected readonly executionEventFacade: ExecutionEventFacade,
-        config$:
-            Observable<Partial<SearchDataSourceConfig<ExecutionEventsQuery.QueryFilter, ExecutionEventField>>>
-        = of({})
+        protected readonly executionEventFacade: ExecutionEventFacade
     ) {
-        super(config$.pipe(map(config => ({
-            ...config,
-            defaultSearchParams:
-                config.defaultSearchParams
-                ?? {
-                    filter: {
-                        asAtTime: new Date().getTime()
-                    },
-                    sortBy: [
-                        {
-                            field: ExecutionEventField.timestamp,
-                            dir: SortDir.DESC
-                        }
-                    ]
-                }
-        }))))
+        super({
+            defaultSearchParams: {
+                filter: {
+                    asAtTime: new Date().getTime()
+                },
+                sortBy: [
+                    {
+                        field: ExecutionEventField.timestamp,
+                        dir: SortDir.DESC
+                    }
+                ]
+            }
+        })
     }
 
     protected getDataObserver(

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -29,7 +29,7 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
     constructor(
         protected readonly executionEventFacade: ExecutionEventFacade
     ) {
-        super({
+        super(() => ({
             defaultSearchParams: {
                 filter: {
                     asAtTime: new Date().getTime()
@@ -41,7 +41,7 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
                     }
                 ]
             }
-        })
+        }))
     }
 
     protected getDataObserver(

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -48,22 +48,7 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
         searchParams: SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>
     ): Observable<ExecutionEventsPageResponse> {
 
-        const queryParams = this.toQueryParams(searchParams)
+        const queryParams = ExecutionEventsQuery.toQueryParams(searchParams)
         return this.executionEventFacade.fetchList(queryParams)
-    }
-
-    protected toQueryParams(
-        searchParams: SearchQuery.SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>,
-    ): ExecutionEventsQuery.QueryParams {
-        const queryFilter = {
-            ...searchParams.filter,
-            ...searchParams.alwaysOnFilter,
-            searchTerm: searchParams.searchTerm,
-        }
-        return {
-            filter: queryFilter,
-            pager: searchParams.pager,
-            sortBy: searchParams.sortBy,
-        }
     }
 }

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -16,7 +16,7 @@
 
 import { Observable } from 'rxjs'
 import { ExecutionEvent, ExecutionEventFacade, ExecutionEventField, ExecutionEventsPageResponse, ExecutionEventsQuery } from 'spline-api'
-import { QuerySorter, SearchDataSource, SearchQuery } from 'spline-utils'
+import { QuerySorter, SearchDataSource, SearchDataSourceConfig, SearchQuery } from 'spline-utils'
 import SortDir = QuerySorter.SortDir;
 import SearchParams = SearchQuery.SearchParams;
 
@@ -26,19 +26,25 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
     ExecutionEventsQuery.QueryFilter,
     ExecutionEventField> {
 
-    constructor(protected readonly executionEventFacade: ExecutionEventFacade) {
-        super()
-
-        this.updateDefaultSearchParams({
-            filter: {
-                asAtTime: new Date().getTime()
-            },
-            sortBy: [
-                {
-                    field: ExecutionEventField.timestamp,
-                    dir: SortDir.DESC
+    constructor(
+        protected readonly executionEventFacade: ExecutionEventFacade,
+        config: Partial<SearchDataSourceConfig<ExecutionEventsQuery.QueryFilter, ExecutionEventField>> = {}
+    ) {
+        super({
+            ...config,
+            defaultSearchParams:
+                config.defaultSearchParams
+                ?? {
+                    filter: {
+                        asAtTime: new Date().getTime()
+                    },
+                    sortBy: [
+                        {
+                            field: ExecutionEventField.timestamp,
+                            dir: SortDir.DESC
+                        }
+                    ]
                 }
-            ]
         })
     }
 

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -83,7 +83,7 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
     ): ExecutionEventsQuery.QueryParams {
         const queryFilter = {
             ...searchParams.filter,
-            ...searchParams.staticFilter,
+            ...searchParams.alwaysOnFilter,
             searchTerm: searchParams.searchTerm,
         }
         return {

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -71,8 +71,7 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
     }
 
     protected getDataObserver(
-        searchParams: SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>,
-        force: boolean,
+        searchParams: SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>
     ): Observable<ExecutionEventsPageResponse> {
 
         const queryParams = this.toQueryParams(searchParams)

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -40,8 +40,6 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
                 }
             ]
         })
-
-        this.updateSearchParams(this.defaultSearchParams)
     }
 
     protected getDataObserver(

--- a/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
+++ b/ui/projects/spline-shared/events/src/data-sources/events.data-source.ts
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-import { Observable } from 'rxjs'
+import { Observable, of } from 'rxjs'
+import { map } from 'rxjs/operators'
 import { ExecutionEvent, ExecutionEventFacade, ExecutionEventField, ExecutionEventsPageResponse, ExecutionEventsQuery } from 'spline-api'
 import { QuerySorter, SearchDataSource, SearchDataSourceConfig, SearchQuery } from 'spline-utils'
 import SortDir = QuerySorter.SortDir;
@@ -28,9 +29,11 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
 
     constructor(
         protected readonly executionEventFacade: ExecutionEventFacade,
-        config: Partial<SearchDataSourceConfig<ExecutionEventsQuery.QueryFilter, ExecutionEventField>> = {}
+        config$:
+            Observable<Partial<SearchDataSourceConfig<ExecutionEventsQuery.QueryFilter, ExecutionEventField>>>
+        = of({})
     ) {
-        super({
+        super(config$.pipe(map(config => ({
             ...config,
             defaultSearchParams:
                 config.defaultSearchParams
@@ -45,7 +48,7 @@ export class EventsDataSource extends SearchDataSource<ExecutionEvent,
                         }
                     ]
                 }
-        })
+        }))))
     }
 
     protected getDataObserver(

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -105,13 +105,6 @@ export abstract class SearchDataSource<TDataRecord = unknown,
         this.updateSearchParams(searchParams, true, false)
     }
 
-    resetSearchParams(): SearchParams<TFilter, TSortableFields> {
-        return this.updateSearchParams({
-            ...this.defaultSearchParams,
-            staticFilter: this.searchParams.staticFilter,
-        }, false, false)
-    }
-
     goToPage(pageIndex: number): void {
         const currentPager = this.searchParams.pager
         if (currentPager.offset !== pageIndex) {

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -88,6 +88,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
             ...this._defaultSearchParams,
             ...value,
         }
+        this.updateSearchParams(this._defaultSearchParams, false)
     }
 
     search(searchTerm: string): void {
@@ -106,10 +107,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
 
     setAlwaysOnFilter(filterValue: TFilter): void {
         // todo: This filter isn't supposed to be modified. Replace it with the default params preset.
-        this._searchParams$.next({
-            ...this.searchParams,
-            ...({ alwaysOnFilter: filterValue }),
-        } as SearchParams<TFilter, TSortableFields>)
+        this.updateSearchParams({ alwaysOnFilter: filterValue }, false)
     }
 
     goToPage(pageIndex: number): void {
@@ -151,16 +149,16 @@ export abstract class SearchDataSource<TDataRecord = unknown,
         })
     }
 
-    updateSearchParams(searchParams: Partial<SearchParams<TFilter, TSortableFields>>): void {
-        // console.log("UPDATE SEARCH PARAMS", searchParams)
-
+    updateSearchParams(searchParams: Partial<SearchParams<TFilter, TSortableFields>>, apply: boolean = true): void {
         const newSearchParams = {
             ...this.searchParams,
             ...searchParams,
         } as SearchParams<TFilter, TSortableFields>
 
         this._searchParams$.next(newSearchParams)
-        this.fetchData(newSearchParams)
+        if (apply) {
+            this.fetchData(newSearchParams)
+        }
     }
 
     connect(collectionViewer: CollectionViewer): Observable<TDataRecord[]> {
@@ -202,7 +200,6 @@ export abstract class SearchDataSource<TDataRecord = unknown,
     }
 
     private fetchData(searchParams: SearchParams<TFilter, TSortableFields>): void {
-
         if (this._activeFetchSubscription) {
             this._activeFetchSubscription.unsubscribe()
         }

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -91,10 +91,6 @@ export abstract class SearchDataSource<TDataRecord = unknown,
         return this.updateSearchParams(this._defaultSearchParams, false, false)
     }
 
-    load(): void {
-        this.fetchData(this.searchParams, false)
-    }
-
     search(searchTerm: string): void {
         const searchParamsWithResetPagination = this.withResetPagination({ searchTerm })
         this.updateSearchParams(searchParamsWithResetPagination, true, false)
@@ -239,8 +235,8 @@ export abstract class SearchDataSource<TDataRecord = unknown,
         searchParams: SearchParams<TFilter, TSortableFields>,
         force: boolean): void {
 
-        if (this.activeFetchSubscription) {
-            this.activeFetchSubscription.unsubscribe()
+        if (this._activeFetchSubscription) {
+            this._activeFetchSubscription.unsubscribe()
         }
 
         this.updateDataState({

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -101,27 +101,8 @@ export abstract class SearchDataSource<TDataRecord = unknown,
     }
 
     setFilter(filterValue: TFilter): void {
-        const searchParams = {
-            filter: filterValue,
-            pager: {
-                limit: this.searchParams.pager.limit,
-                offset: 0,
-            },
-        }
-
+        const searchParams = this.withResetPagination({ filter: filterValue })
         this.updateSearchParams(searchParams, true, false)
-    }
-
-    refresh(): void {
-        // reset pagination
-        const newSearchParams = {
-            pager: {
-                offset: 0,
-                limit: this.searchParams.pager.limit,
-            },
-        }
-
-        this.updateSearchParams(newSearchParams, true, true)
     }
 
     resetSearchParams(): SearchParams<TFilter, TSortableFields> {

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -25,11 +25,11 @@ import { SplineRecord } from '../heplers'
 import { PageResponse, QuerySorter } from '../query'
 
 import { SearchQuery } from './search-query.models'
-import DataState = SearchQuery.DataState
-import DEFAULT_RENDER_DATA = SearchQuery.DEFAULT_RENDER_DATA
-import DEFAULT_SEARCH_PARAMS = SearchQuery.DEFAULT_SEARCH_PARAMS
-import DEFAULT_SERVER_POLLING_INTERVAL = SearchQuery.DEFAULT_SERVER_POLL_INTERVAL
-import SearchParams = SearchQuery.SearchParams
+import DataState = SearchQuery.DataState;
+import DEFAULT_RENDER_DATA = SearchQuery.DEFAULT_RENDER_DATA;
+import DEFAULT_SEARCH_PARAMS = SearchQuery.DEFAULT_SEARCH_PARAMS;
+import DEFAULT_SERVER_POLLING_INTERVAL = SearchQuery.DEFAULT_SERVER_POLL_INTERVAL;
+import SearchParams = SearchQuery.SearchParams;
 
 
 export abstract class SearchDataSource<TDataRecord = unknown,
@@ -105,8 +105,11 @@ export abstract class SearchDataSource<TDataRecord = unknown,
     }
 
     setAlwaysOnFilter(filterValue: TFilter): void {
-        const searchParams = this.withResetPagination({ alwaysOnFilter: filterValue })
-        this.updateSearchParams(searchParams)
+        // todo: This filter isn't supposed to be modified. Replace it with the default params preset.
+        this._searchParams$.next({
+            ...this.searchParams,
+            ...({ alwaysOnFilter: filterValue }),
+        } as SearchParams<TFilter, TSortableFields>)
     }
 
     goToPage(pageIndex: number): void {
@@ -149,15 +152,15 @@ export abstract class SearchDataSource<TDataRecord = unknown,
     }
 
     updateSearchParams(searchParams: Partial<SearchParams<TFilter, TSortableFields>>): void {
+        // console.log("UPDATE SEARCH PARAMS", searchParams)
+
         const newSearchParams = {
             ...this.searchParams,
             ...searchParams,
         } as SearchParams<TFilter, TSortableFields>
 
-        if (!isEqual(newSearchParams, this.searchParams)) {
-            this._searchParams$.next(newSearchParams)
-            this.fetchData(newSearchParams)
-        }
+        this._searchParams$.next(newSearchParams)
+        this.fetchData(newSearchParams)
     }
 
     connect(collectionViewer: CollectionViewer): Observable<TDataRecord[]> {

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -96,7 +96,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
     }
 
     sort(sortBy: QuerySorter.FieldSorter<TSortableFields>[]): void {
-        this.updateSearchParams({ sortBy })
+        this.updateSearchParams(this.withResetPagination({ sortBy }))
     }
 
     setFilter(filterValue: TFilter): void {

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -34,7 +34,6 @@ import SearchParams = SearchQuery.SearchParams;
 
 export type SearchDataSourceConfig<TFilter extends SplineRecord = {}, TSortableFields = string> = {
     defaultSearchParams: Partial<SearchParams<TFilter, TSortableFields>>
-    alwaysOnFilters: TFilter
 }
 
 export abstract class SearchDataSource<TDataRecord = unknown,
@@ -73,10 +72,6 @@ export abstract class SearchDataSource<TDataRecord = unknown,
             const defaultSearchParams = {
                 ...DEFAULT_SEARCH_PARAMS,
                 ...config.defaultSearchParams,
-                alwaysOnFilter: {
-                    ...DEFAULT_SEARCH_PARAMS.alwaysOnFilter,
-                    ...config.alwaysOnFilters
-                }
             }
             this._defaultSearchParams = defaultSearchParams
             this._searchParams$ = new BehaviorSubject(defaultSearchParams)

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -105,6 +105,11 @@ export abstract class SearchDataSource<TDataRecord = unknown,
         this.updateSearchParams(searchParams, true, false)
     }
 
+    setAlwaysOnFilter(filterValue: TFilter): void {
+        const searchParams = this.withResetPagination({ alwaysOnFilter: filterValue })
+        this.updateSearchParams(searchParams, true, false)
+    }
+
     goToPage(pageIndex: number): void {
         const currentPager = this.searchParams.pager
         if (currentPager.offset !== pageIndex) {

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -45,13 +45,13 @@ export abstract class SearchDataSource<TDataRecord = unknown,
 
     readonly disconnected$: Observable<void>
 
-    protected readonly _dataState$ = new BehaviorSubject<DataState<TData>>(DEFAULT_RENDER_DATA)
-    protected readonly _searchParams$ = new BehaviorSubject<SearchParams<TFilter, TSortableFields>>(DEFAULT_SEARCH_PARAMS)
+    private readonly _dataState$ = new BehaviorSubject<DataState<TData>>(DEFAULT_RENDER_DATA)
+    private readonly _searchParams$ = new BehaviorSubject<SearchParams<TFilter, TSortableFields>>(DEFAULT_SEARCH_PARAMS)
 
-    protected _defaultSearchParams: SearchParams<TFilter, TSortableFields> = DEFAULT_SEARCH_PARAMS
-    protected readonly _disconnected$ = new Subject<void>()
+    private _defaultSearchParams: SearchParams<TFilter, TSortableFields> = DEFAULT_SEARCH_PARAMS
+    private readonly _disconnected$ = new Subject<void>()
 
-    private activeFetchSubscription: Subscription
+    private _activeFetchSubscription: Subscription
 
     protected constructor() {
 
@@ -88,7 +88,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
             ...this._defaultSearchParams,
             ...value,
         }
-        return this.updateSearchParams(this.defaultSearchParams, false, false)
+        return this.updateSearchParams(this._defaultSearchParams, false, false)
     }
 
     load(): void {
@@ -247,7 +247,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
             loadingProcessing: ProcessingStore.eventProcessingStart(this.dataState.loadingProcessing),
         })
 
-        this.activeFetchSubscription = this.getDataObserver(searchParams, force)
+        this._activeFetchSubscription = this.getDataObserver(searchParams, force)
             .pipe(
                 catchError((error) => {
                     this.updateDataState({

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -185,7 +185,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
             this._searchParams$.next(newSearchParams)
 
             if (apply) {
-                this.fetchData(newSearchParams, forceApply)
+                this.fetchData(newSearchParams)
             }
         }
 
@@ -221,8 +221,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
 
     // DATA stuff
 
-    protected abstract getDataObserver(searchParams: SearchParams<TFilter, TSortableFields>,
-                                       force: boolean): Observable<TData>;
+    protected abstract getDataObserver(searchParams: SearchParams<TFilter, TSortableFields>): Observable<TData>
 
     private updateDataState(dataState: Partial<DataState<TData>>): void {
         this._dataState$.next({
@@ -231,9 +230,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
         })
     }
 
-    private fetchData(
-        searchParams: SearchParams<TFilter, TSortableFields>,
-        force: boolean): void {
+    private fetchData(searchParams: SearchParams<TFilter, TSortableFields>): void {
 
         if (this._activeFetchSubscription) {
             this._activeFetchSubscription.unsubscribe()
@@ -243,7 +240,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
             loadingProcessing: ProcessingStore.eventProcessingStart(this.dataState.loadingProcessing),
         })
 
-        this._activeFetchSubscription = this.getDataObserver(searchParams, force)
+        this._activeFetchSubscription = this.getDataObserver(searchParams)
             .pipe(
                 catchError((error) => {
                     this.updateDataState({
@@ -285,7 +282,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
                             asAtTime: undefined
                         }
                     }
-                    return this.getDataObserver(freshSearchParams, undefined)
+                    return this.getDataObserver(freshSearchParams)
                         .pipe(
                             first(),
                             catchError(() => EMPTY)

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-data-source.model.ts
@@ -83,31 +83,30 @@ export abstract class SearchDataSource<TDataRecord = unknown,
         return this._dataState$.getValue()
     }
 
-    updateDefaultSearchParams(value: Partial<SearchParams<TFilter, TSortableFields>>): SearchParams<TFilter, TSortableFields> {
+    updateDefaultSearchParams(value: Partial<SearchParams<TFilter, TSortableFields>>): void {
         this._defaultSearchParams = {
             ...this._defaultSearchParams,
             ...value,
         }
-        return this.updateSearchParams(this._defaultSearchParams, false, false)
     }
 
     search(searchTerm: string): void {
         const searchParamsWithResetPagination = this.withResetPagination({ searchTerm })
-        this.updateSearchParams(searchParamsWithResetPagination, true, false)
+        this.updateSearchParams(searchParamsWithResetPagination)
     }
 
     sort(sortBy: QuerySorter.FieldSorter<TSortableFields>[]): void {
-        this.updateSearchParams({ sortBy }, true, false)
+        this.updateSearchParams({ sortBy })
     }
 
     setFilter(filterValue: TFilter): void {
         const searchParams = this.withResetPagination({ filter: filterValue })
-        this.updateSearchParams(searchParams, true, false)
+        this.updateSearchParams(searchParams)
     }
 
     setAlwaysOnFilter(filterValue: TFilter): void {
         const searchParams = this.withResetPagination({ alwaysOnFilter: filterValue })
-        this.updateSearchParams(searchParams, true, false)
+        this.updateSearchParams(searchParams)
     }
 
     goToPage(pageIndex: number): void {
@@ -118,7 +117,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
                     ...currentPager,
                     offset: pageIndex * currentPager.limit,
                 },
-            }, true, false)
+            })
         }
         else {
             console.warn('Nothing to do. The current offset equals to the target offset.')
@@ -132,7 +131,7 @@ export abstract class SearchDataSource<TDataRecord = unknown,
                 ...currentPager,
                 offset: currentPager.offset + currentPager.limit,
             },
-        }, true, false)
+        })
     }
 
     prevPage(): void {
@@ -146,29 +145,19 @@ export abstract class SearchDataSource<TDataRecord = unknown,
                 ...currentPager,
                 offset: currentPager.offset - currentPager.limit,
             },
-        }, true, false)
+        })
     }
 
-    updateSearchParams(
-        searchParams: Partial<SearchParams<TFilter, TSortableFields>>,
-        // If apply === true then rendered data will be recalculated based on new searchParams value and the current entitiesList collection
-        apply: boolean,
-        forceApply: boolean): SearchParams<TFilter, TSortableFields> {
-
+    updateSearchParams(searchParams: Partial<SearchParams<TFilter, TSortableFields>>): void {
         const newSearchParams = {
             ...this.searchParams,
             ...searchParams,
         } as SearchParams<TFilter, TSortableFields>
 
-        if (forceApply || !isEqual(newSearchParams, this.searchParams)) {
+        if (!isEqual(newSearchParams, this.searchParams)) {
             this._searchParams$.next(newSearchParams)
-
-            if (apply) {
-                this.fetchData(newSearchParams)
-            }
+            this.fetchData(newSearchParams)
         }
-
-        return newSearchParams
     }
 
     connect(collectionViewer: CollectionViewer): Observable<TDataRecord[]> {

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-query.models.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-query.models.ts
@@ -54,7 +54,7 @@ export namespace SearchQuery {
         loadingProcessing: ProcessingStore.getDefaultProcessingState(),
     }
 
-    export const DEFAULT_SERVER_POLL_INTERVAL = 5000 // msec
+    export const DEFAULT_SERVER_POLL_INTERVAL = 2000 // msec
 
     export function toMatSortable(fieldSorter: QuerySorter.FieldSorter, disableClear = true): MatSortable {
         return {

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-query.models.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-query.models.ts
@@ -31,7 +31,7 @@ export namespace SearchQuery {
     export interface SearchParams<TFilter extends SplineRecord = {}, TSortableField = string> {
         pager: QueryPager
         filter: TFilter
-        staticFilter: TFilter // filter which will be always applied
+        alwaysOnFilter: TFilter
         sortBy: QuerySorter.FieldSorter<TSortableField>[]
         searchTerm: string
     }
@@ -39,7 +39,7 @@ export namespace SearchQuery {
     export const DEFAULT_SEARCH_PARAMS: SearchParams<any, any> = Object.freeze({
         pager: { ...DEFAULT_PAGER },
         filter: {},
-        staticFilter: {},
+        alwaysOnFilter: {},
         sortBy: [],
         searchTerm: '',
     })

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search-query.models.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search-query.models.ts
@@ -54,7 +54,7 @@ export namespace SearchQuery {
         loadingProcessing: ProcessingStore.getDefaultProcessingState(),
     }
 
-    export const DEFAULT_SERVER_POLL_INTERVAL = 2000 // msec
+    export const DEFAULT_SERVER_POLL_INTERVAL = 5000 // msec
 
     export function toMatSortable(fieldSorter: QuerySorter.FieldSorter, disableClear = true): MatSortable {
         return {

--- a/ui/projects/spline-utils/main/src/common/models/search-query/simple-data-source.model.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/simple-data-source.model.ts
@@ -65,10 +65,6 @@ export abstract class SimpleDataSource<TData, TFilter extends SplineRecord = {}>
         return this._dataState$.getValue()
     }
 
-    load(force: boolean = false): void {
-        this.fetchData(this.filter, force).subscribe()
-    }
-
     setFilter(filterValue: TFilter, apply: boolean = true, force: boolean = false): void {
         this.onFilterChanged$.next({ filter: filterValue, apply, force })
     }
@@ -94,18 +90,18 @@ export abstract class SimpleDataSource<TData, TFilter extends SplineRecord = {}>
             .pipe(
                 takeUntil(this.disconnected$),
                 tap((payload) => this._filter$.next(payload.filter)),
-                switchMap((payload) => this.fetchData(payload.filter, payload.force)),
+                switchMap((payload) => this.fetchData(payload.filter)),
             )
             .subscribe()
     }
 
-    protected fetchData(filterValue: TFilter, force: boolean = false): Observable<TData> {
+    private fetchData(filterValue: TFilter): Observable<TData> {
 
         this.updateDataState({
             loadingProcessing: ProcessingStore.eventProcessingStart(this.dataState.loadingProcessing),
         })
 
-        return this.getDataObserver(filterValue, force)
+        return this.getDataObserver(filterValue)
             .pipe(
                 catchError((error) => {
                     this.updateDataState({
@@ -134,6 +130,6 @@ export abstract class SimpleDataSource<TData, TFilter extends SplineRecord = {}>
     }
 
 
-    protected abstract getDataObserver(filterValue: TFilter, force: boolean): Observable<TData>;
+    protected abstract getDataObserver(filterValue: TFilter): Observable<TData>;
 }
 

--- a/ui/src/app/app-routing.module.ts
+++ b/ui/src/app/app-routing.module.ts
@@ -67,7 +67,8 @@ const routes: Routes = [
         RouterModule.forRoot(routes, {
             useHash: false,
             scrollPositionRestoration: 'top',
-            relativeLinkResolution: 'legacy'
+            relativeLinkResolution: 'legacy',
+            onSameUrlNavigation: 'reload'
         }),
     ],
     exports: [RouterModule],

--- a/ui/src/modules/data-sources/data-sources/ds-state-history.data-source.ts
+++ b/ui/src/modules/data-sources/data-sources/ds-state-history.data-source.ts
@@ -54,22 +54,7 @@ export class DsStateHistoryDataSource extends SearchDataSource<ExecutionEvent,
         searchParams: SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>
     ): Observable<ExecutionEventsPageResponse> {
 
-        const queryParams = this.toQueryParams(searchParams)
+        const queryParams = ExecutionEventsQuery.toQueryParams(searchParams)
         return this.executionEventFacade.fetchList(queryParams)
-    }
-
-    protected toQueryParams(
-        searchParams: SearchQuery.SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>,
-    ): ExecutionEventsQuery.QueryParams {
-        const queryFilter = {
-            ...searchParams.filter,
-            ...searchParams.alwaysOnFilter,
-            searchTerm: searchParams.searchTerm,
-        }
-        return {
-            filter: queryFilter,
-            pager: searchParams.pager,
-            sortBy: searchParams.sortBy,
-        }
     }
 }

--- a/ui/src/modules/data-sources/data-sources/ds-state-history.data-source.ts
+++ b/ui/src/modules/data-sources/data-sources/ds-state-history.data-source.ts
@@ -31,7 +31,7 @@ export class DsStateHistoryDataSource extends SearchDataSource<ExecutionEvent,
         protected readonly executionEventFacade: ExecutionEventFacade,
         dsUri$: Observable<string>
     ) {
-        super(dsUri$.pipe(map(dsUri => ({
+        super(dsUri$.pipe(map(dsUri => () => ({
             defaultSearchParams: {
                 alwaysOnFilter: {
                     dataSourceUri: dsUri

--- a/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
+++ b/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
@@ -32,7 +32,7 @@ export class SplineDataSourcesDataSource extends EventsDataSource {
     constructor(protected readonly executionEventFacade: ExecutionEventFacade) {
         super(executionEventFacade)
 
-        this.updateAndApplyDefaultSearchParams({
+        this.updateDefaultSearchParams({
             filter: {
                 asAtTime: new Date().getTime()
             },

--- a/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
+++ b/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Observable } from 'rxjs'
+import { Observable, of } from 'rxjs'
 import {
     ExecutionEventFacade,
     ExecutionEventField,
@@ -32,7 +32,7 @@ export class SplineDataSourcesDataSource extends EventsDataSource {
     constructor(protected readonly executionEventFacade: ExecutionEventFacade) {
         super(
             executionEventFacade,
-            {
+            of({
                 defaultSearchParams: {
                     filter: {
                         asAtTime: new Date().getTime()
@@ -44,7 +44,7 @@ export class SplineDataSourcesDataSource extends EventsDataSource {
                         }
                     ]
                 }
-            })
+            }))
     }
 
     protected getDataObserver(

--- a/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
+++ b/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
@@ -43,6 +43,8 @@ export class SplineDataSourcesDataSource extends EventsDataSource {
                 }
             ]
         })
+
+        this.updateSearchParams(this.defaultSearchParams)
     }
 
     protected getDataObserver(

--- a/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
+++ b/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
@@ -29,7 +29,7 @@ export class SplineDataSourcesDataSource extends SearchDataSource<ExecutionEvent
     constructor(
         protected readonly executionEventFacade: ExecutionEventFacade
     ) {
-        super({
+        super(() => ({
             defaultSearchParams: {
                 filter: {
                     asAtTime: new Date().getTime()
@@ -41,7 +41,7 @@ export class SplineDataSourcesDataSource extends SearchDataSource<ExecutionEvent
                     }
                 ]
             }
-        })
+        }))
     }
 
     protected getDataObserver(

--- a/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
+++ b/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
@@ -30,19 +30,21 @@ import SortDir = QuerySorter.SortDir
 export class SplineDataSourcesDataSource extends EventsDataSource {
 
     constructor(protected readonly executionEventFacade: ExecutionEventFacade) {
-        super(executionEventFacade)
-
-        this.updateDefaultSearchParams({
-            filter: {
-                asAtTime: new Date().getTime()
-            },
-            sortBy: [
-                {
-                    field: ExecutionEventField.dataSourceName,
-                    dir: SortDir.ASC
+        super(
+            executionEventFacade,
+            {
+                defaultSearchParams: {
+                    filter: {
+                        asAtTime: new Date().getTime()
+                    },
+                    sortBy: [
+                        {
+                            field: ExecutionEventField.dataSourceName,
+                            dir: SortDir.ASC
+                        }
+                    ]
                 }
-            ]
-        })
+            })
     }
 
     protected getDataObserver(

--- a/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
+++ b/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
@@ -43,8 +43,6 @@ export class SplineDataSourcesDataSource extends EventsDataSource {
                 }
             ]
         })
-
-        this.updateSearchParams(this.defaultSearchParams)
     }
 
     protected getDataObserver(

--- a/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
+++ b/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
@@ -46,8 +46,7 @@ export class SplineDataSourcesDataSource extends EventsDataSource {
     }
 
     protected getDataObserver(
-        searchParams: SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>,
-        force: boolean,
+        searchParams: SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>
     ): Observable<ExecutionEventsPageResponse> {
 
         const queryParams = this.toQueryParams(searchParams)

--- a/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
+++ b/ui/src/modules/data-sources/data-sources/spline-data-sources.data-source.ts
@@ -21,12 +21,10 @@ import SearchParams = SearchQuery.SearchParams;
 import SortDir = QuerySorter.SortDir;
 
 
-export class SplineDataSourcesDataSource
-
-    extends SearchDataSource<ExecutionEvent,
-        ExecutionEventsPageResponse,
-        ExecutionEventsQuery.QueryFilter,
-        ExecutionEventField> {
+export class SplineDataSourcesDataSource extends SearchDataSource<ExecutionEvent,
+    ExecutionEventsPageResponse,
+    ExecutionEventsQuery.QueryFilter,
+    ExecutionEventField> {
 
     constructor(
         protected readonly executionEventFacade: ExecutionEventFacade
@@ -50,22 +48,8 @@ export class SplineDataSourcesDataSource
         searchParams: SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>
     ): Observable<ExecutionEventsPageResponse> {
 
-        const queryParams = this.toQueryParams(searchParams)
+        const queryParams = ExecutionEventsQuery.toQueryParams(searchParams)
         return this.executionEventFacade.fetchListAggregatedByDataSource(queryParams)
     }
 
-    protected toQueryParams(
-        searchParams: SearchQuery.SearchParams<ExecutionEventsQuery.QueryFilter, ExecutionEventField>,
-    ): ExecutionEventsQuery.QueryParams {
-        const queryFilter = {
-            ...searchParams.filter,
-            ...searchParams.alwaysOnFilter,
-            searchTerm: searchParams.searchTerm,
-        }
-        return {
-            filter: queryFilter,
-            pager: searchParams.pager,
-            sortBy: searchParams.sortBy,
-        }
-    }
 }

--- a/ui/src/modules/data-sources/pages/overview/history/ds-overview-history.page.component.ts
+++ b/ui/src/modules/data-sources/pages/overview/history/ds-overview-history.page.component.ts
@@ -46,8 +46,10 @@ import { DsOverviewHistoryPage } from './ds-overview-history.page.models'
                         withLatestFrom(store.dataSourceInfo$),
                         filter(([isInitialized, dataSourceInfo]) => isInitialized && !!dataSourceInfo),
                         map(([, dataSourceInfo]) => ({
-                            alwaysOnFilters: {
-                                dataSourceUri: dataSourceInfo.uri
+                            defaultSearchParams: {
+                                alwaysOnFilter: {
+                                    dataSourceUri: dataSourceInfo.uri
+                                }
                             }
                         })))
 

--- a/ui/src/modules/data-sources/pages/overview/history/ds-overview-history.page.component.ts
+++ b/ui/src/modules/data-sources/pages/overview/history/ds-overview-history.page.component.ts
@@ -73,7 +73,7 @@ export class DsOverviewHistoryPageComponent extends BaseLocalStateComponent<DsOv
                 takeUntil(this.destroyed$),
             )
             .subscribe((dataSourceInfo) => {
-                this.dataSource.updateAndApplyDefaultSearchParams({
+                this.dataSource.updateDefaultSearchParams({
                     filter: {
                         dataSourceUri: dataSourceInfo.uri
                     }

--- a/ui/src/modules/data-sources/pages/overview/history/ds-overview-history.page.component.ts
+++ b/ui/src/modules/data-sources/pages/overview/history/ds-overview-history.page.component.ts
@@ -16,7 +16,7 @@
 
 import { Component, OnInit } from '@angular/core'
 import { Observable } from 'rxjs'
-import { filter, map, takeUntil, withLatestFrom } from 'rxjs/operators'
+import { map, takeUntil } from 'rxjs/operators'
 import { ExecutionEvent, ExecutionEventFacade, ExecutionEventsQuery, SplineDataSourceInfo } from 'spline-api'
 import { DynamicFilterFactory, DynamicFilterModel } from 'spline-common/dynamic-filter'
 import { DtCellCustomEvent } from 'spline-common/dynamic-table'
@@ -41,17 +41,13 @@ import { DsOverviewHistoryPage } from './ds-overview-history.page.models'
                 executionEventFacade: ExecutionEventFacade,
                 store: DsOverviewStoreFacade) => {
 
-                const config$ = store.isInitialized$
-                    .pipe(
-                        withLatestFrom(store.dataSourceInfo$),
-                        filter(([isInitialized, dataSourceInfo]) => isInitialized && !!dataSourceInfo),
-                        map(([, dataSourceInfo]) => ({
-                            defaultSearchParams: {
-                                alwaysOnFilter: {
-                                    dataSourceUri: dataSourceInfo.uri
-                                }
-                            }
-                        })))
+                const config$ = store.dataSourceInfo$.pipe(map((dataSourceInfo) => ({
+                    defaultSearchParams: {
+                        alwaysOnFilter: {
+                            dataSourceUri: dataSourceInfo.uri
+                        }
+                    }
+                })))
 
                 return new DsStateHistoryDataSource(executionEventFacade, config$)
             },
@@ -79,12 +75,7 @@ export class DsOverviewHistoryPageComponent extends BaseLocalStateComponent<DsOv
             DsOverviewHistoryPage.getDefaultState()
         )
 
-        this.dataSourceInfo$ = this.store.isInitialized$
-            .pipe(
-                withLatestFrom(this.store.dataSourceInfo$),
-                filter(([isInitialized, dataSourceInfo]) => isInitialized && !!dataSourceInfo),
-                map(([isInitialized, dataSourceInfo]) => dataSourceInfo),
-            )
+        this.dataSourceInfo$ = this.store.dataSourceInfo$
     }
 
     ngOnInit(): void {

--- a/ui/src/modules/data-sources/pages/overview/history/ds-overview-history.page.component.ts
+++ b/ui/src/modules/data-sources/pages/overview/history/ds-overview-history.page.component.ts
@@ -41,15 +41,9 @@ import { DsOverviewHistoryPage } from './ds-overview-history.page.models'
                 executionEventFacade: ExecutionEventFacade,
                 store: DsOverviewStoreFacade) => {
 
-                const config$ = store.dataSourceInfo$.pipe(map((dataSourceInfo) => ({
-                    defaultSearchParams: {
-                        alwaysOnFilter: {
-                            dataSourceUri: dataSourceInfo.uri
-                        }
-                    }
-                })))
+                const dsUri$ = store.dataSourceInfo$.pipe(map((dataSourceInfo) => dataSourceInfo.uri))
 
-                return new DsStateHistoryDataSource(executionEventFacade, config$)
+                return new DsStateHistoryDataSource(executionEventFacade, dsUri$)
             },
             deps: [
                 ExecutionEventFacade,

--- a/ui/src/modules/data-sources/pages/overview/history/ds-overview-history.page.component.ts
+++ b/ui/src/modules/data-sources/pages/overview/history/ds-overview-history.page.component.ts
@@ -73,10 +73,8 @@ export class DsOverviewHistoryPageComponent extends BaseLocalStateComponent<DsOv
                 takeUntil(this.destroyed$),
             )
             .subscribe((dataSourceInfo) => {
-                this.dataSource.updateDefaultSearchParams({
-                    filter: {
-                        dataSourceUri: dataSourceInfo.uri
-                    }
+                this.dataSource.setAlwaysOnFilter({
+                    dataSourceUri: dataSourceInfo.uri
                 })
             })
     }

--- a/ui/src/modules/data-sources/services/store/ds-overview.store.facade.ts
+++ b/ui/src/modules/data-sources/services/store/ds-overview.store.facade.ts
@@ -27,7 +27,7 @@ import { DsOverviewStore, DsOverviewStoreActions, DsOverviewStoreSelectors } fro
 export class DsOverviewStoreFacade {
 
     readonly state$: Observable<DsOverviewStore.State>
-    readonly isInitialized$: Observable<boolean>
+    readonly isInitialized$: Observable<boolean> // TODO: why is it needed?
     readonly dataSourceInfo$: Observable<SplineDataSourceInfo>
 
     constructor(private readonly store: Store<any>) {

--- a/ui/src/modules/data-sources/services/store/ds-overview.store.facade.ts
+++ b/ui/src/modules/data-sources/services/store/ds-overview.store.facade.ts
@@ -27,12 +27,10 @@ import { DsOverviewStore, DsOverviewStoreActions, DsOverviewStoreSelectors } fro
 export class DsOverviewStoreFacade {
 
     readonly state$: Observable<DsOverviewStore.State>
-    readonly isInitialized$: Observable<boolean> // TODO: why is it needed?
     readonly dataSourceInfo$: Observable<SplineDataSourceInfo>
 
     constructor(private readonly store: Store<any>) {
         this.state$ = this.store.pipe(select(DsOverviewStoreSelectors.rootState))
-        this.isInitialized$ = this.store.pipe(select(DsOverviewStoreSelectors.isInitialized))
         this.dataSourceInfo$ = this.store.pipe(select(DsOverviewStoreSelectors.dataSourceInfo))
     }
 

--- a/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
+++ b/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
@@ -43,8 +43,6 @@ export class EventLineageListDataSource extends SearchDataSource<ExecutionEventL
                 }
             ]
         })
-
-        this.updateSearchParams(this.defaultSearchParams)
     }
 
     protected getDataObserver(

--- a/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
+++ b/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
@@ -43,6 +43,8 @@ export class EventLineageListDataSource extends SearchDataSource<ExecutionEventL
                 }
             ]
         })
+
+        this.updateSearchParams(this.defaultSearchParams)
     }
 
     protected getDataObserver(

--- a/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
+++ b/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
@@ -32,7 +32,7 @@ export class EventLineageListDataSource extends SearchDataSource<ExecutionEventL
     constructor(private readonly executionEventFacade: ExecutionEventFacade) {
         super()
 
-        this.updateAndApplyDefaultSearchParams({
+        this.updateDefaultSearchParams({
             filter: {
                 asAtTime: new Date().getTime()
             },

--- a/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
+++ b/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
@@ -30,18 +30,18 @@ export class EventLineageListDataSource extends SearchDataSource<ExecutionEventL
     }
 
     constructor(private readonly executionEventFacade: ExecutionEventFacade) {
-        super()
-
-        this.updateDefaultSearchParams({
-            filter: {
-                asAtTime: new Date().getTime()
-            },
-            sortBy: [
-                {
-                    field: ExecutionEventField.timestamp,
-                    dir: SortDir.DESC
-                }
-            ]
+        super({
+            defaultSearchParams: {
+                filter: {
+                    asAtTime: new Date().getTime()
+                },
+                sortBy: [
+                    {
+                        field: ExecutionEventField.timestamp,
+                        dir: SortDir.DESC
+                    }
+                ]
+            }
         })
     }
 

--- a/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
+++ b/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
@@ -46,8 +46,7 @@ export class EventLineageListDataSource extends SearchDataSource<ExecutionEventL
     }
 
     protected getDataObserver(
-        searchParams: SearchQuery.SearchParams,
-        force: boolean
+        searchParams: SearchQuery.SearchParams
     ): Observable<PageResponse<ExecutionEventLineageList.LineageRecord>> {
         return this.executionEventFacade.fetchLineageOverview(this._executionEventId)
             .pipe(

--- a/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
+++ b/ui/src/modules/events/data-sources/event-lineage-list.data-source.ts
@@ -30,7 +30,7 @@ export class EventLineageListDataSource extends SearchDataSource<ExecutionEventL
     }
 
     constructor(private readonly executionEventFacade: ExecutionEventFacade) {
-        super({
+        super(() => ({
             defaultSearchParams: {
                 filter: {
                     asAtTime: new Date().getTime()
@@ -42,7 +42,7 @@ export class EventLineageListDataSource extends SearchDataSource<ExecutionEventL
                     }
                 ]
             }
-        })
+        }))
     }
 
     protected getDataObserver(

--- a/ui/src/modules/events/data-sources/operation-details-list-data.source.ts
+++ b/ui/src/modules/events/data-sources/operation-details-list-data.source.ts
@@ -29,7 +29,7 @@ export class OperationDetailsListDataSource extends SimpleDataSource<OperationDe
         super()
     }
 
-    protected getDataObserver(filter: OperationDetailsListFilter, force: boolean): Observable<OperationDetails[]> {
+    protected getDataObserver(filter: OperationDetailsListFilter): Observable<OperationDetails[]> {
         return filter.operationIds.length
             ? forkJoin(
                 filter.operationIds

--- a/ui/src/modules/plans/data-sources/operation-details.data-source.ts
+++ b/ui/src/modules/plans/data-sources/operation-details.data-source.ts
@@ -29,7 +29,7 @@ export class OperationDetailsDataSource extends SimpleDataSource<OperationDetail
         super()
     }
 
-    protected getDataObserver(filter: OperationDetailsFilter, force: boolean): Observable<OperationDetails> {
+    protected getDataObserver(filter: OperationDetailsFilter): Observable<OperationDetails> {
         return this.executionPlanFacade.fetchOperationDetails(filter.operationId)
     }
 


### PR DESCRIPTION
- Reset default filters on re-navigation to the initial route (click on the same navigation menu item)
- Refactor `SearchDataSource` to simplify observable pipes:
  - Remove unused methods
  - Get rid of `apply` and `forceApply` parameters
  - Make `defaultSearchParams` immutable
  - Rename `staticFilters` to `alwaysOnFilters` and move them to the `defaultSearchParams`
  - Remove unnecessary `store.isInitialized$`
  - Flatten `EventDataSource` hierarchy
  - Fix a typo in `package.json`