### PR TITLE
Bugfix/spline UI 152 overwrite label

### DIFF
--- a/ui/projects/spline-api/src/lib/execution-event/models/entities/execution-event/execution-event.models.ts
+++ b/ui/projects/spline-api/src/lib/execution-event/models/entities/execution-event/execution-event.models.ts
@@ -15,6 +15,8 @@
  */
 
 
+import { isBoolean } from 'lodash-es'
+
 import { DataSourceWriteMode, SplineDataSourceInfo, uriToDatasourceInfo } from '../data-source'
 
 
@@ -54,11 +56,18 @@ export type ExecutionEvent =
     }
 
 export function toExecutionEvent(entity: ExecutionEventDto): ExecutionEvent {
+    const append = entity[ExecutionEventField.append]
+    const writeMode =
+        isBoolean(append)
+            ? append
+                ? DataSourceWriteMode.Append
+                : DataSourceWriteMode.Overwrite
+            : null
     return {
         ...entity,
         applicationName: entity.applicationName ?? entity.executionEventId,
         executedAt: new Date(entity.timestamp),
         dataSourceInfo: uriToDatasourceInfo(entity[ExecutionEventField.dataSourceUri], entity.dataSourceName),
-        writeMode: entity[ExecutionEventField.append] ? DataSourceWriteMode.Append : DataSourceWriteMode.Overwrite
+        writeMode: writeMode
     }
 }

--- a/ui/projects/spline-common/main/assets/i18n/common/en.json
+++ b/ui/projects/spline-common/main/assets/i18n/common/en.json
@@ -30,7 +30,7 @@
         },
         "DATA_SOURCE_WRITE_MODE": {
             "APPEND": "Append",
-            "OVERRIDE": "Override"
+            "OVERWRITE": "Overwrite"
         }
     }
 }

--- a/ui/projects/spline-common/main/src/common/models/data-source-write-mode.models.ts
+++ b/ui/projects/spline-common/main/src/common/models/data-source-write-mode.models.ts
@@ -30,7 +30,7 @@ export function getDataSourceWriteModeLabel(writeMode: DataSourceWriteMode): str
             return `${prefix}.APPEND`
 
         case DataSourceWriteMode.Overwrite:
-            return `${prefix}.OVERRIDE`
+            return `${prefix}.OVERWRITE`
 
         default:
             console.warn(`Unknown write mode: ${writeMode}`)

--- a/ui/projects/spline-shared/dynamic-table/main/assets/i18n/shared-dynamic-table/en.json
+++ b/ui/projects/spline-shared/dynamic-table/main/assets/i18n/shared-dynamic-table/en.json
@@ -2,7 +2,7 @@
     "SHARED": {
         "DYNAMIC_TABLE": {
             "DS_WRITE_MODE__APPEND": "Append",
-            "DS_WRITE_MODE__OVERRIDE": "Override",
+            "DS_WRITE_MODE__OVERWRITE": "Overwrite",
             "BUTTON__REFRESH": "Refresh",
             "TOOLTIP__UPDATE_AVAILABLE": "New data is available on the server"
         }

--- a/ui/projects/spline-shared/dynamic-table/main/src/dynamic-table/schemas/spline-data-source-shared.dt-schema.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/dynamic-table/schemas/spline-data-source-shared.dt-schema.ts
@@ -47,7 +47,7 @@ export namespace SplineDataSourceSharedDtSchema {
                 const writeMode = getWriteModeFn(rowData)
                 return writeMode === DataSourceWriteMode.Append
                     ? 'SHARED.DYNAMIC_TABLE.DS_WRITE_MODE__APPEND'
-                    : 'SHARED.DYNAMIC_TABLE.DS_WRITE_MODE__OVERRIDE'
+                    : 'SHARED.DYNAMIC_TABLE.DS_WRITE_MODE__OVERWRITE'
             },
             options: (rowData) => {
                 const writeMode = getWriteModeFn(rowData)

--- a/ui/projects/spline-shared/dynamic-table/main/src/dynamic-table/schemas/spline-data-source-shared.dt-schema.ts
+++ b/ui/projects/spline-shared/dynamic-table/main/src/dynamic-table/schemas/spline-data-source-shared.dt-schema.ts
@@ -44,10 +44,14 @@ export namespace SplineDataSourceSharedDtSchema {
         return {
             type: DtCellLabel.TYPE,
             value: (rowData) => {
-                const writeMode = getWriteModeFn(rowData)
-                return writeMode === DataSourceWriteMode.Append
-                    ? 'SHARED.DYNAMIC_TABLE.DS_WRITE_MODE__APPEND'
-                    : 'SHARED.DYNAMIC_TABLE.DS_WRITE_MODE__OVERWRITE'
+                switch (getWriteModeFn(rowData)) {
+                    case DataSourceWriteMode.Append:
+                        return 'SHARED.DYNAMIC_TABLE.DS_WRITE_MODE__APPEND'
+                    case DataSourceWriteMode.Overwrite:
+                        return 'SHARED.DYNAMIC_TABLE.DS_WRITE_MODE__OVERWRITE'
+                    default:
+                        return null
+                }
             },
             options: (rowData) => {
                 const writeMode = getWriteModeFn(rowData)

--- a/ui/src/modules/data-sources/store/reducers/ds-overview-details.reducers.ts
+++ b/ui/src/modules/data-sources/store/reducers/ds-overview-details.reducers.ts
@@ -19,7 +19,6 @@ import { SplineColors } from 'spline-common'
 import { SdWidgetCard, SdWidgetExpansionPanel, SdWidgetSimpleRecord, SdWidgetTitle, SplineDataViewSchema } from 'spline-common/data-view'
 import { SdWidgetAttributesTree } from 'spline-shared/attributes'
 import { SgEventNodeInfoShared } from 'spline-shared/data-view'
-import { EventsRouting } from 'spline-shared/events'
 import { DateTimeHelpers, ProcessingStore } from 'spline-utils'
 
 import { DsOverviewDetailsStoreActions } from '../actions'
@@ -127,7 +126,7 @@ export namespace DsOverviewDetailsStore {
                         label: 'DATA_SOURCES.DETAILS__WRITE_MODE',
                         value: executionEvent.writeMode === DataSourceWriteMode.Append
                             ? 'Append'
-                            : 'Override',
+                            : 'Overwrite',
                     },
                     {
                         label: 'DATA_SOURCES.DETAILS__EXECUTION_EVENT',


### PR DESCRIPTION
- fixes a typo: _override_ to _overwrite_
- Make `writeMode` nullable. Do not treat `null` as `"Overwrite"`