### PR TITLE
issue #171 TypeError: Cannot read properties of null (reading 'name')…

### DIFF
--- a/ui/projects/spline-shared/attributes/src/components/attributes-tree-widget/sd-widget-attributes-tree.component.ts
+++ b/ui/projects/spline-shared/attributes/src/components/attributes-tree-widget/sd-widget-attributes-tree.component.ts
@@ -31,8 +31,6 @@ export class SdWidgetAttributesTreeComponent extends SdWidgetBaseComponent<SdWid
     selectedAttributeId$: Observable<string | null>
     attributesTree$: Observable<SplineAttributesTree.Tree | null>
 
-    @Output() event$ = new EventEmitter<SdWidgetAttributesTree.EventSelectedAttrChanged>()
-
     constructor() {
         super()
 

--- a/ui/projects/spline-shared/expression/src/components/sd-widgets/expression/sd-widget-expression.component.ts
+++ b/ui/projects/spline-shared/expression/src/components/sd-widgets/expression/sd-widget-expression.component.ts
@@ -15,7 +15,6 @@
  */
 
 import { Component } from '@angular/core'
-import { BehaviorSubject } from 'rxjs'
 import { SdWidgetBaseComponent } from 'spline-common/data-view'
 
 import { SdWidgetExpression } from '../../../models'
@@ -26,5 +25,5 @@ import { SdWidgetExpression } from '../../../models'
     templateUrl: './sd-widget-expression.component.html',
 })
 export class SdWidgetExpressionComponent extends SdWidgetBaseComponent<SdWidgetExpression.Data, SdWidgetExpression.Options> {
-    readonly data$ = new BehaviorSubject<SdWidgetExpression.Data>(null)
+
 }

--- a/ui/src/modules/events/components/event-node-info/event-node-info.component.ts
+++ b/ui/src/modules/events/components/event-node-info/event-node-info.component.ts
@@ -105,7 +105,7 @@ export class EventNodeInfoComponent extends BaseLocalStateComponent<EventNodeInf
             const nodeRelations: EventNodeInfo.NodeRelationsInfo = changes.nodeRelations.currentValue
 
             const operationIds = nodeRelations.node.type === ExecutionEventLineageNodeType.DataSource && nodeRelations?.parents?.length > 0
-                ? nodeRelations.parents.map(node => executionPlanIdToWriteOperationId(node.id, node.agentInfo.version))
+                ? nodeRelations.parents.map(node => executionPlanIdToWriteOperationId(node.id, node.agentInfo?.version))
                 : []
 
             this.updateState({

--- a/ui/src/modules/plans/components/operation-info/operation-info.component.ts
+++ b/ui/src/modules/plans/components/operation-info/operation-info.component.ts
@@ -25,7 +25,7 @@ import {
 } from '@angular/core'
 import { BehaviorSubject } from 'rxjs'
 import { filter, takeUntil } from 'rxjs/operators'
-import { ExecutionPlanFacade, ExecutionPlanLineageNode } from 'spline-api'
+import { ExecutionPlanAgentInfo, ExecutionPlanFacade, ExecutionPlanLineageNode } from 'spline-api'
 import { SplineDataWidgetEvent } from 'spline-common/data-view'
 import { SdWidgetAttributesTree } from 'spline-shared/attributes'
 import { SgNodeCardDataView } from 'spline-shared/data-view'
@@ -55,6 +55,8 @@ export class OperationInfoComponent extends BaseLocalStateComponent<OperationInf
 
     @Input() node: ExecutionPlanLineageNode
 
+    @Input() agentInfo: ExecutionPlanAgentInfo | undefined
+
     @Input() set selectedAttributeId(attributeId: string | null) {
         this.selectedAttributeId$.next(attributeId)
     }
@@ -77,7 +79,7 @@ export class OperationInfoComponent extends BaseLocalStateComponent<OperationInf
                     operationDvs: OperationInfo.toDataViewSchema(data.operation),
                     inputsDvs: OperationInfo.toInputsDvs(data, this.selectedAttributeId$),
                     outputDvs: OperationInfo.toOutputsDvs(data, this.selectedAttributeId$),
-                    detailsDvs: OperationInfo.toDetailsDvs(data),
+                    detailsDvs: OperationInfo.toDetailsDvs(data, this.agentInfo),
                     inputsNumber: data?.inputs?.length ?? 0
                 }),
             )

--- a/ui/src/modules/plans/components/plan-header/plan-header.component.html
+++ b/ui/src/modules/plans/components/plan-header/plan-header.component.html
@@ -23,7 +23,7 @@
     </spline-data-record>
 
     <spline-data-record [label]="'PLANS.PLAN_INFO__DETAILS__AGENT_INFO' | translate">
-        {{ executionPlan.agentInfo.name }} {{ executionPlan.agentInfo.version }}
+        {{ executionPlan.agentInfo?.name }} {{ executionPlan.agentInfo?.version }}
     </spline-data-record>
 
     <spline-data-record [label]="'Output' | translate">

--- a/ui/src/modules/plans/models/operation/operation-info.models.ts
+++ b/ui/src/modules/plans/models/operation/operation-info.models.ts
@@ -15,7 +15,7 @@
  */
 
 import { Observable } from 'rxjs'
-import { Operation, OperationDetails, OperationType } from 'spline-api'
+import { ExecutionPlanAgentInfo, Operation, OperationDetails, OperationType } from 'spline-api'
 import { SdWidgetCard, SplineDataViewSchema } from 'spline-common/data-view'
 import { SgNodeCardDataView } from 'spline-shared/data-view'
 import { SgNodeControl } from 'spline-shared/graph'
@@ -121,39 +121,48 @@ export namespace OperationInfo {
         )
     }
 
-    export function toDetailsDvs(operationDetails: OperationDetails): SplineDataViewSchema | null {
+    export function toDetailsDvs(
+        operationDetails: OperationDetails,
+        agentInfo: ExecutionPlanAgentInfo | undefined
+    ): SplineDataViewSchema | null {
         const nodeType = toNodeType(operationDetails.operation.type, operationDetails.operation.name)
-        switch (nodeType) {
-            case SgNodeControl.NodeType.Read:
-                return OperationRead.toDataViewSchema(operationDetails)
+        if (agentInfo?.name == 'spline') {
+            switch (nodeType) {
+                case SgNodeControl.NodeType.Read:
+                    return OperationRead.toDataViewSchema(operationDetails)
 
-            case SgNodeControl.NodeType.Write:
-                return OperationWrite.toDataViewSchema(operationDetails)
+                case SgNodeControl.NodeType.Write:
+                    return OperationWrite.toDataViewSchema(operationDetails)
 
-            case SgNodeControl.NodeType.Filter:
-                return OperationFilter.toDataViewSchema(operationDetails)
+                case SgNodeControl.NodeType.Filter:
+                    return OperationFilter.toDataViewSchema(operationDetails)
 
-            case SgNodeControl.NodeType.Alias:
-                return OperationAlias.toDataViewSchema(operationDetails)
+                case SgNodeControl.NodeType.Alias:
+                    return OperationAlias.toDataViewSchema(operationDetails)
 
-            case SgNodeControl.NodeType.Join:
-                return OperationJoin.toDataViewSchema(operationDetails)
+                case SgNodeControl.NodeType.Join:
+                    return OperationJoin.toDataViewSchema(operationDetails)
 
-            case SgNodeControl.NodeType.Projection:
-                return OperationProjection.toDataViewSchema(operationDetails)
+                case SgNodeControl.NodeType.Projection:
+                    return OperationProjection.toDataViewSchema(operationDetails)
 
-            case SgNodeControl.NodeType.Aggregate:
-                return OperationAggregate.toDataViewSchema(operationDetails)
+                case SgNodeControl.NodeType.Aggregate:
+                    return OperationAggregate.toDataViewSchema(operationDetails)
 
-            case SgNodeControl.NodeType.Sort:
-                return OperationSort.toDataViewSchema(operationDetails)
+                case SgNodeControl.NodeType.Sort:
+                    return OperationSort.toDataViewSchema(operationDetails)
 
-            case SgNodeControl.NodeType.Transformation:
-            case SgNodeControl.NodeType.Generic:
-                return OperationGeneric.toDataViewSchema(operationDetails)
+                case SgNodeControl.NodeType.Transformation:
+                case SgNodeControl.NodeType.Generic:
+                    return OperationGeneric.toDataViewSchema(operationDetails)
 
-            default:
-                return null
+                default:
+                    return null
+            }
+        }
+        else {
+            // no detailed view for metadata collected by 3rd-party agents
+            return OperationGeneric.toDataViewSchema(operationDetails)
         }
     }
 

--- a/ui/src/modules/plans/models/plan/plan-info.models.ts
+++ b/ui/src/modules/plans/models/plan/plan-info.models.ts
@@ -49,7 +49,7 @@ export namespace PlanInfo {
                         },
                         {
                             label: 'PLANS.PLAN_INFO__DETAILS__AGENT_INFO',
-                            value: `${executionPlan.agentInfo.name} ${executionPlan.agentInfo.version}`,
+                            value: `${executionPlan.agentInfo?.name} ${executionPlan.agentInfo?.version}`,
                         },
                     ]),
                 ],

--- a/ui/src/modules/plans/pages/plan-overview/plan-overview.page.component.html
+++ b/ui/src/modules/plans/pages/plan-overview/plan-overview.page.component.html
@@ -70,6 +70,7 @@
                         <plan-operation-info (focusNode$)="onNodeFocus($event.nodeId)"
                                              (selectedAttributeChanged$)="onSelectedAttributeChanged($event.attributeId)"
                                              [node]="store.selectedNode$ | async"
+                                             [agentInfo]="(store.executionPlan$ | async).agentInfo"
                                              [selectedAttributeId]="state.selectedAttributeId">
                         </plan-operation-info>
 


### PR DESCRIPTION
Fixed by treating all operations of execution plans collected by non-Spline agents as generic operations.
Detailed (by type) operation views are implicitly dependent on Spline Spark Agent data structure.