### PR TITLE
issue #195 Operation ID format should be flexible

### DIFF
--- a/ui/projects/spline-api/src/lib/execution-event/models/entities/execution-plan/execution-plan.models.ts
+++ b/ui/projects/spline-api/src/lib/execution-event/models/entities/execution-plan/execution-plan.models.ts
@@ -73,8 +73,6 @@ export type ExecutionPlanExtraInfoDto =
 export function toExecutionPlan(entity: ExecutionPlanDto): ExecutionPlan {
     return {
         id: entity._id,
-        // TODO: remove extra?.appName in the next minor release, 0.7.*.
-        //       For now we support it, but it is deprecated. Only `entity.name` field should be used instead in future.
         name: entity.name?.length ? entity.name : planSystemInfoToName(entity.systemInfo),
         inputDataSources: entity.inputs.map(toDataSourceInfo),
         outputDataSource: toDataSourceInfo(entity.output),
@@ -94,35 +92,6 @@ export function toExecutionPlanExtraInfo(entity: ExecutionPlanExtraInfoDto): Exe
         attributes: entity?.attributes || [],
         dataTypes: (entity?.dataTypes || []).map(toAttributeDataType),
     }
-}
-
-export function executionPlanIdToWriteOperationId(executionPlanId: string, agentVersion: string | undefined = undefined): string {
-    // This method assumes a particular format of the write operation ID depending on the agent version.
-    // Strictly speaking that's not correct as there is no stable convention about the operation ID format.
-    // It's OK for a short term solution, but should be changed as soon as possible.
-    // For a long-term solution see https://github.com/AbsaOSS/spline/issues/982
-
-    let isAgentVersionAtLeast07
-    if (agentVersion) {
-        const SEMVER_REGEXP = new RegExp([
-            /^/,
-            /(0|[1-9]\d*)\./,
-            /(0|[1-9]\d*)\./,
-            /(0|[1-9]\d*)/,
-            /(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?/,
-            /(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?/,
-            /$/
-        ].map(r => r.source).join(''))
-        const [, vMajor, vMinor] = SEMVER_REGEXP.exec(agentVersion)
-        isAgentVersionAtLeast07 = +vMajor > 0 || +vMinor > 6
-    }
-    else {
-        // assume that UUID ver 5 means Agent 0.7+ (!!! VERY WEAK ASSUMPTION !!!)
-        isAgentVersionAtLeast07 = executionPlanId.charAt(14) === '5'
-    }
-    return isAgentVersionAtLeast07
-        ? `${executionPlanId}:op-0`
-        : `${executionPlanId}:0`
 }
 
 export function operationIdToExecutionPlanId(operationId: string): string {

--- a/ui/projects/spline-api/src/lib/execution-event/services/execution-plan.facade.ts
+++ b/ui/projects/spline-api/src/lib/execution-event/services/execution-plan.facade.ts
@@ -68,6 +68,18 @@ export class ExecutionPlanFacade extends BaseFacade {
             )
     }
 
+    fetchExecutionPlanRootOperationDetails(executionPlanId: string): Observable<OperationDetails> {
+        const url = this.toUrl(`execution-plans/${executionPlanId}/write-op`)
+        return this.http.get<OperationDetailsDto>(url)
+            .pipe(
+                map(toOperationDetails),
+                catchError(error => {
+                    console.error(error)
+                    return throwError(error)
+                })
+            )
+    }
+
     fetchAttributeLineage(executionPlanId: string, attributeId: string): Observable<OperationAttributeLineage> {
         let params = new HttpParams()
         params = params.append('execId', executionPlanId)

--- a/ui/src/modules/data-sources/store/effects/ds-overview-details.effects.ts
+++ b/ui/src/modules/data-sources/store/effects/ds-overview-details.effects.ts
@@ -17,9 +17,8 @@
 import { Injectable } from '@angular/core'
 import { Actions, createEffect, ofType } from '@ngrx/effects'
 import { Store } from '@ngrx/store'
-import { of } from 'rxjs'
 import { catchError, filter, map, switchMap } from 'rxjs/operators'
-import { ExecutionPlanFacade, executionPlanIdToWriteOperationId } from 'spline-api'
+import { ExecutionPlanFacade } from 'spline-api'
 
 import { DsOverviewDetailsStoreActions } from '../actions'
 import fromActions = DsOverviewDetailsStoreActions
@@ -34,13 +33,13 @@ export class DsOverviewDetailsEffects {
         .pipe(
             ofType<fromActions.Init>(fromActions.ActionTypes.Init),
             switchMap(({ payload }) =>
-                this.executionPlanFacade.fetchOperationDetails(executionPlanIdToWriteOperationId(payload.executionEvent.executionPlanId))
+                this.executionPlanFacade.fetchExecutionPlanRootOperationDetails(payload.executionEvent.executionPlanId)
                     .pipe(
                         catchError((error) => {
                             this.store.dispatch(
                                 new fromActions.InitError({ error })
                             )
-                            return of(null)
+                            throw error
                         }),
                         map((oneOperationsDetails) => ({
                             operationsDetails: [oneOperationsDetails],

--- a/ui/src/modules/events/components/event-node-info/event-node-info.component.html
+++ b/ui/src/modules/events/components/event-node-info/event-node-info.component.html
@@ -21,7 +21,9 @@
     <!-- ./LOADER -->
 
     <!-- ERROR -->
-    <spline-content-error *ngIf="state.loadingProcessing.processingError"></spline-content-error>
+    <spline-content-error *ngIf="state.loadingProcessing.processingError"
+                          [statusCode]="state.loadingProcessing.processingError?.status">
+    </spline-content-error>
     <!-- ./ERROR -->
 
     <ng-container *ngIf="!state.loadingProcessing.processing">

--- a/ui/src/modules/events/components/event-node-info/event-node-info.component.ts
+++ b/ui/src/modules/events/components/event-node-info/event-node-info.component.ts
@@ -17,7 +17,7 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core'
 import { isEqual } from 'lodash-es'
 import { delay, distinctUntilChanged, filter, takeUntil } from 'rxjs/operators'
-import { ExecutionEventLineageNodeType, ExecutionPlanFacade, executionPlanIdToWriteOperationId } from 'spline-api'
+import { ExecutionEventLineageNodeType, ExecutionPlanFacade } from 'spline-api'
 import { SplineDataWidgetEvent } from 'spline-common/data-view'
 import { SgNodeCardDataView } from 'spline-shared/data-view'
 import { BaseLocalStateComponent, GenericEventInfo, ProcessingStore } from 'spline-utils'
@@ -104,8 +104,8 @@ export class EventNodeInfoComponent extends BaseLocalStateComponent<EventNodeInf
         if (changes?.nodeRelations && !!changes.nodeRelations.currentValue) {
             const nodeRelations: EventNodeInfo.NodeRelationsInfo = changes.nodeRelations.currentValue
 
-            const operationIds = nodeRelations.node.type === ExecutionEventLineageNodeType.DataSource && nodeRelations?.parents?.length > 0
-                ? nodeRelations.parents.map(node => executionPlanIdToWriteOperationId(node.id, node.agentInfo?.version))
+            const executionPlanIds = nodeRelations.node.type === ExecutionEventLineageNodeType.DataSource && nodeRelations?.parents?.length > 0
+                ? nodeRelations.parents.map(node => node.id)
                 : []
 
             this.updateState({
@@ -114,7 +114,7 @@ export class EventNodeInfoComponent extends BaseLocalStateComponent<EventNodeInf
 
             // set filter and trigger data fetching
             this.dataSource.setFilter({
-                operationIds
+                executionPlanIds
             })
         }
     }

--- a/ui/src/modules/events/data-sources/operation-details-list-data.source.ts
+++ b/ui/src/modules/events/data-sources/operation-details-list-data.source.ts
@@ -20,7 +20,7 @@ import { SimpleDataSource } from 'spline-utils'
 
 
 export type OperationDetailsListFilter = {
-    operationIds: string[]
+    executionPlanIds: string[]
 }
 
 export class OperationDetailsListDataSource extends SimpleDataSource<OperationDetails[], OperationDetailsListFilter> {
@@ -30,10 +30,10 @@ export class OperationDetailsListDataSource extends SimpleDataSource<OperationDe
     }
 
     protected getDataObserver(filter: OperationDetailsListFilter): Observable<OperationDetails[]> {
-        return filter.operationIds.length
+        return filter.executionPlanIds.length
             ? forkJoin(
-                filter.operationIds
-                    .map(id => this.executionPlanFacade.fetchOperationDetails(id))
+                filter.executionPlanIds
+                    .map(planId => this.executionPlanFacade.fetchExecutionPlanRootOperationDetails(planId))
             )
             : of([])
     }


### PR DESCRIPTION
Replace the hard coded operation ID format with the call of a new dedicated resource `/execution-plans/{id}/write-op`