### PR TITLE
fix #230 moved takeUntil to the end of the list

### DIFF
--- a/ui/projects/spline-utils/main/src/common/directives/router-link-active-pattern/router-link-active-pattern.directive.ts
+++ b/ui/projects/spline-utils/main/src/common/directives/router-link-active-pattern/router-link-active-pattern.directive.ts
@@ -44,8 +44,8 @@ export class RouterLinkActivePatternDirective extends BaseDirective implements O
 
         this.router.events
             .pipe(
-                takeUntil(this.destroyed$),
-                filter(event => event instanceof NavigationEnd)
+                filter(event => event instanceof NavigationEnd),
+                takeUntil(this.destroyed$)
             )
             .subscribe((event: NavigationEnd) => {
                 this.onUrlChanged()

--- a/ui/projects/spline-utils/main/src/common/models/search-query/search.factory-store.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/search.factory-store.ts
@@ -71,12 +71,12 @@ export abstract class SearchFactoryStore<TDataRecord = unknown,
         const configLike$ = isObservable(configInput) ? configInput : of(configInput)
         const configProvider$ = configLike$
             .pipe(
-                takeUntil(this._disconnected$),
                 first(),
                 map(configFnOrObj => {
                     return isFunction(configFnOrObj) ? configFnOrObj : (() => configFnOrObj)
                 }),
-                share()
+                share(),
+                takeUntil(this._disconnected$)
             )
 
         this.asyncInitDefaultSearchParams(configProvider$)

--- a/ui/projects/spline-utils/main/src/common/models/search-query/simple.factory-store.ts
+++ b/ui/projects/spline-utils/main/src/common/models/search-query/simple.factory-store.ts
@@ -88,9 +88,9 @@ export abstract class SimpleFactoryStore<TData, TFilter extends SplineRecord = {
         // FILTER CHANGED EVENT
         this.onFilterChanged$
             .pipe(
-                takeUntil(this.disconnected$),
                 tap((payload) => this._filter$.next(payload.filter)),
-                switchMap((payload) => this.fetchData(payload.filter))
+                switchMap((payload) => this.fetchData(payload.filter)),
+                takeUntil(this.disconnected$)
             )
             .subscribe()
     }

--- a/ui/projects/spline-utils/main/src/common/rxjs-operators/when-page-visible.operator.ts
+++ b/ui/projects/spline-utils/main/src/common/rxjs-operators/when-page-visible.operator.ts
@@ -33,8 +33,8 @@ export function whenPageVisible() {
 
     return function <T>(source: Observable<T>) {
         return source.pipe(
-            takeUntil(pageHidden$),
-            repeatWhen(() => pageVisible$)
+            repeatWhen(() => pageVisible$),
+            takeUntil(pageHidden$)
         )
     }
 }


### PR DESCRIPTION
Moved all the takeUntil methods to the end of the list of pipes in the spline-utils folder.