### PR TITLE
Fix HTTP 503 service unavailable message

### DIFF
--- a/ui/projects/spline-common/main/assets/i18n/spline-common/en.json
+++ b/ui/projects/spline-common/main/assets/i18n/spline-common/en.json
@@ -19,6 +19,7 @@
         "UNEXPECTED_ERROR__MESSAGE": "Unexpected error.",
         "SERVER_COMMUNICATION_ERROR__MESSAGE": "Unexpected server error.",
         "SERVER_COMMUNICATION_ERROR__MESSAGE__NOT_FOUND": "Not Found :(",
+        "SERVER_COMMUNICATION_ERROR__MESSAGE__SERVICE_UNAVAILABLE": "Server is temporary unavailable.",
         "SERVER_COMMUNICATION_ERROR__MESSAGE__FAILURE": "Server is unavailable.",
         "SERVER_COMMUNICATION_ERROR__ID": "Error Id",
         "SERVER_COMMUNICATION_ERROR__STATUS_CODE": "Status Code",

--- a/ui/projects/spline-common/main/src/common/component/content-error/__tests__/spline-content-error.component.spec.ts
+++ b/ui/projects/spline-common/main/src/common/component/content-error/__tests__/spline-content-error.component.spec.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { SimpleChange } from '@angular/core'
+
+import { SplineContentErrorComponent } from '../spline-content-error.component'
+
+
+describe('SplineContentErrorComponent', () => {
+
+    function setStatusCode(component: SplineContentErrorComponent, statusCode: number): void {
+        component.ngOnChanges({
+            statusCode: new SimpleChange(undefined, statusCode, true)
+        })
+    }
+
+    test('returns a service unavailable message for HTTP 503', () => {
+        const component = new SplineContentErrorComponent()
+
+        setStatusCode(component, 503)
+
+        expect(component.errorMessage).toEqual('COMMON.SERVER_COMMUNICATION_ERROR__MESSAGE__SERVICE_UNAVAILABLE')
+    })
+
+    test('keeps generic server error message for other HTTP 5xx errors', () => {
+        const component = new SplineContentErrorComponent()
+
+        setStatusCode(component, 500)
+
+        expect(component.errorMessage).toEqual('COMMON.SERVER_COMMUNICATION_ERROR__MESSAGE')
+    })
+})

--- a/ui/projects/spline-common/main/src/common/component/content-error/spline-content-error.component.ts
+++ b/ui/projects/spline-common/main/src/common/component/content-error/spline-content-error.component.ts
@@ -46,6 +46,9 @@ export class SplineContentErrorComponent implements OnChanges {
         else if (statusCode === 404) {
             return 'COMMON.SERVER_COMMUNICATION_ERROR__MESSAGE__NOT_FOUND'
         }
+        else if (statusCode === 503) {
+            return 'COMMON.SERVER_COMMUNICATION_ERROR__MESSAGE__SERVICE_UNAVAILABLE'
+        }
         else if (statusCode >= 500 && statusCode < 600) {
             return 'COMMON.SERVER_COMMUNICATION_ERROR__MESSAGE'
         }


### PR DESCRIPTION
## Summary
- Add a dedicated HTTP 503 branch in `SplineContentErrorComponent`.
- Show `Server is temporary unavailable.` for 503 responses instead of the generic unexpected server error message.
- Keep other 5xx responses mapped to the existing generic server error message.

## Verification
- `npx jest projects/spline-common/main/src/common/component/content-error/__tests__/spline-content-error.component.spec.ts --runInBand`
- `npx eslint projects/spline-common/main/src/common/component/content-error/spline-content-error.component.ts projects/spline-common/main/src/common/component/content-error/__tests__/spline-content-error.component.spec.ts --quiet`
- `git diff --check`

Fixes #272